### PR TITLE
chore: Update pipewire-rs and libspa-sys to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -256,7 +256,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -366,6 +366,7 @@ checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -485,7 +486,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.8.0",
 ]
 
 [[package]]
@@ -842,6 +843,16 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
@@ -852,8 +863,9 @@ dependencies = [
 
 [[package]]
 name = "libspa"
-version = "0.6.0"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs#90d338976f55bcdd96432d905a98c0918de50fce"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0434617020ddca18b86067912970c55410ca654cdafd775480322f50b857a8c4"
 dependencies = [
  "bitflags 2.3.3",
  "cc",
@@ -868,8 +880,9 @@ dependencies = [
 
 [[package]]
 name = "libspa-sys"
-version = "0.6.0"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs#90d338976f55bcdd96432d905a98c0918de50fce"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e70ca3f3e70f858ef363046d06178c427b4e0b63d210c95fd87d752679d345"
 dependencies = [
  "bindgen",
  "cc",
@@ -1069,8 +1082,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipewire"
-version = "0.6.0"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs#90d338976f55bcdd96432d905a98c0918de50fce"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d009c8dd65e890b515a71950f7e4c801523b8894ff33863a40830bf762e9e9"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -1085,8 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "pipewire-sys"
-version = "0.6.0"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs#90d338976f55bcdd96432d905a98c0918de50fce"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890c084e7b737246cb4799c86b71a0e4da536031ff7473dd639eba9f95039f64"
 dependencies = [
  "bindgen",
  "libspa-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,11 @@ cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols" }
 cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols" }
 futures = "0.3"
 memmap2 = "0.6.1"
-# pipewire = { git = "https://github.com/pop-os/pipewire-rs" }
-pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
+pipewire = "0.7.2"
 png = "0.17.5"
 rustix = { version = "0.37.19", features = ["fs"] }
 serde = "1.0.143"
-# spa_sys = { package = "libspa-sys", git = "https://github.com/pop-os/pipewire-rs" }
-spa_sys = { package = "libspa-sys", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
+spa_sys = { package = "libspa-sys", version = "0.7.2" }
 tempfile = "3.5.0"
 tokio = { version = "1.19.2", features = ["macros", "net", "rt", "sync"] }
 wayland-client = { version = "0.30.0" }


### PR DESCRIPTION
libspa 0.7.2 (a dependency of pipewire-rs) contains a fix[0] for a build error which was occuring on some environments, which was affecting xdg-desktop-portal-cosmic as well.

The 0.7.2 release is very recent (08/25/2023), therefore switching to it directly without pointing to git.

[0] https://gitlab.freedesktop.org/pipewire/pipewire-rs/-/commit/d70d83d7afc601eb3ef244379846e0d5f46dd0e5