### PR TITLE
Add a dummy implementation of Access

### DIFF
--- a/data/cosmic.portal
+++ b/data/cosmic.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.cosmic
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast
+Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast
 UseIn=cosmic

--- a/src/access.rs
+++ b/src/access.rs
@@ -1,0 +1,51 @@
+#![allow(dead_code, unused_variables)]
+
+use zbus::zvariant;
+
+use crate::wayland::WaylandHelper;
+use crate::PortalResponse;
+
+#[derive(zvariant::DeserializeDict, zvariant::Type, Debug)]
+#[zvariant(signature = "a{sv}")]
+struct AccessDialogOptions {
+    modal: Option<bool>,
+    deny_label: Option<String>,
+    grant_label: Option<String>,
+    icon: Option<String>,
+    choices: Option<Vec<(String, String, Vec<(String, String)>, String)>>,
+}
+
+#[derive(zvariant::SerializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+struct AccessDialogResult {
+    choices: Vec<(String, String)>,
+}
+
+pub struct Access {
+    wayland_helper: WaylandHelper,
+}
+
+impl Access {
+    pub fn new(wayland_helper: WaylandHelper) -> Self {
+        Self { wayland_helper }
+    }
+}
+
+#[zbus::dbus_interface(name = "org.freedesktop.impl.portal.Access")]
+impl Access {
+    async fn access_dialog(
+        &self,
+        handle: zvariant::ObjectPath<'_>,
+        app_id: &str,
+        parent_window: &str,
+        title: &str,
+        subtitle: &str,
+        body: &str,
+        option: AccessDialogOptions,
+    ) -> PortalResponse<AccessDialogResult> {
+        log::debug!("Access dialog {app_id} {parent_window} {title} {subtitle} {body} {option:?}");
+        PortalResponse::Success(AccessDialogResult {
+            choices: Vec::new(),
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, future};
 use zbus::zvariant;
 
+mod access;
+use access::Access;
 mod buffer;
 mod documents;
 mod screenshot;
@@ -95,6 +97,7 @@ async fn main() -> zbus::Result<()> {
 
     let _connection = zbus::ConnectionBuilder::session()?
         .name(DBUS_NAME)?
+        .serve_at(DBUS_PATH, Access::new(wayland_helper.clone()))?
         .serve_at(DBUS_PATH, Screenshot::new(wayland_helper.clone()))?
         .serve_at(DBUS_PATH, ScreenCast::new(wayland_helper))?
         .build()


### PR DESCRIPTION
In xdg-desktop-portal 1.15+, the screenshot interface would not be exposed if there is no Access implementation. Add a dummy one to make it work again.

According to my testing this dummy impl is not invoked when screenshot took place...