### PR TITLE
fix: better layout of window images

### DIFF
--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -121,10 +121,13 @@ where
                     .get(&output.name)
                     .cloned()
                     .unwrap_or_default();
+                let total_img_width = imgs.iter().map(|img| img.width()).sum::<u32>();
+
                 let img_buttons = imgs
                     .into_iter()
                     .enumerate()
                     .map(|(i, img)| {
+                        let portion = (img.width() * u16::MAX as u32 / total_img_width).max(1);
                         container(
                             cosmic::widget::button(
                                 image::Image::new(image::Handle::from_pixels(
@@ -138,7 +141,7 @@ where
                             .style(cosmic::theme::Button::Image),
                         )
                         .align_x(alignment::Horizontal::Center)
-                        .width(Length::FillPortion(1))
+                        .width(Length::FillPortion(portion as u16))
                         .into()
                     })
                     .collect();


### PR DESCRIPTION
![Screenshot_2024-01-19_10-28-52](https://github.com/pop-os/xdg-desktop-portal-cosmic/assets/48420062/28900914-3400-4bf3-aae9-96cc712b1344)
![Screenshot_2024-01-19_10-27-20](https://github.com/pop-os/xdg-desktop-portal-cosmic/assets/48420062/7a18e708-29c1-4f0b-88d6-284a67ef927a)

This better allocates space for windows of different sizes.