### PR TITLE
feat: portals configuration file; use `gnome-keyring` for Secrets portal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ install:
 	install -Dm0755 target/$(TARGET)/$(BIN) $(DESTDIR)$(libexecdir)/$(BIN)
 	install -Dm0644 data/$(DBUS_NAME).service $(DESTDIR)/$(datadir)/dbus-1/services/$(DBUS_NAME).service
 	install -Dm0644 data/cosmic.portal $(DESTDIR)/$(datadir)/xdg-desktop-portal/portals/cosmic.portal
+	install -Dm0644 data/cosmic-portals.conf $(DESTDIR)/$(datadir)/xdg-desktop-portal/cosmic-portals.conf
 	find 'data'/'icons' -type f -exec echo {} \; \
 		| rev \
 		| cut -d'/' -f-3 \

--- a/data/cosmic-portals.conf
+++ b/data/cosmic-portals.conf
@@ -1,0 +1,3 @@
+[preferred]
+default=cosmic;gtk;
+org.freedesktop.impl.portal.Secret=gnome-keyring;


### PR DESCRIPTION
I noticed that I couldn't run apps like Fractal ( https://flathub.org/apps/org.gnome.Fractal ) in COSMIC, because there's no COSMIC implementation of the Secret portal ( https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html ) and the built-in implementation in `gnome-keyring` specifically only suggests to `xdg-desktop-portal` that it should be used in GNOME ( https://gitlab.gnome.org/GNOME/gnome-keyring/-/blob/master/daemon/gnome-keyring.portal )

Without a recommended per-desktop portal configuration file, `xdg-desktop-portal` can only rely on those `UseIn=` fields to figure out which implementations to use for which portals

The `UseIn=` field in *.portal files is deprecated in favour of per-desktop portal configuration files: https://flatpak.github.io/xdg-desktop-portal/docs/backends.html (although we probably shouldn't remove the `UseIn=` field for now)

This PR adds such a per-desktop- portal configuration file, and specifically asks `xdg-desktop-portal` to rely on `gnome-keyring` 's implementation of the Secret portal, and my testing shows that Fractal now works as expected

I'm happy to change this to a different Secret portal implementation as necessary, but I'm not currently sure what the plan is for keyrings under COSMIC