### PR TITLE
Testing / improvements for screencast portal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,27 +4,31 @@ version = 3
 
 [[package]]
 name = "accesskit"
-version = "0.11.0"
-source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#16e0d60cf91b255ed6d9ac5c47bd3d1e878f17d8"
+version = "0.12.2"
+source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#5f9b61c8264000d001499c902562422e13efa7a8"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.15.0"
-source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#16e0d60cf91b255ed6d9ac5c47bd3d1e878f17d8"
+version = "0.17.0"
+source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#5f9b61c8264000d001499c902562422e13efa7a8"
 dependencies = [
  "accesskit",
 ]
 
 [[package]]
 name = "accesskit_unix"
-version = "0.5.0"
-source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#16e0d60cf91b255ed6d9ac5c47bd3d1e878f17d8"
+version = "0.7.1"
+source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#5f9b61c8264000d001499c902562422e13efa7a8"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "async-channel 1.9.0",
+ "async-channel",
+ "async-executor",
+ "async-task",
  "atspi",
  "futures-lite 1.13.0",
+ "futures-util",
+ "once_cell",
  "serde",
  "zbus",
 ]
@@ -162,6 +166,8 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac22eda5891cc086690cb6fa10121c0390de0e3b04eb269f2d766b00d3f2d81"
 dependencies = [
+ "async-fs 2.1.1",
+ "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
@@ -178,23 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ashpd"
-version = "0.7.0"
-source = "git+https://github.com/bilelmoussaoui/ashpd#11e056f379a2bcc67f0dedb75d93f6fbe6ec2c36"
-dependencies = [
- "async-fs 2.1.1",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "serde",
- "serde_repr",
- "url",
- "zbus",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,24 +195,13 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
-dependencies = [
- "concurrent-queue",
- "event-listener 4.0.3",
- "event-listener-strategy",
+ "event-listener 5.0.0",
+ "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
 ]
@@ -320,7 +298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
- "event-listener-strategy",
+ "event-listener-strategy 0.4.0",
  "pin-project-lite",
 ]
 
@@ -428,29 +406,50 @@ dependencies = [
 
 [[package]]
 name = "atspi"
-version = "0.10.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674e7a3376837b2e7d12d34d58ac47073c491dc3bf6f71a7adaf687d4d817faa"
+checksum = "6059f350ab6f593ea00727b334265c4dfc7fd442ee32d264794bd9bdc68e87ca"
 dependencies = [
- "async-recursion",
- "async-trait",
- "atspi-macros",
- "enumflags2",
- "futures-lite 1.13.0",
- "serde",
- "tracing",
- "zbus",
- "zbus_names",
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
 ]
 
 [[package]]
-name = "atspi-macros"
-version = "0.2.0"
+name = "atspi-common"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb4870a32c0eaa17e35bca0e6b16020635157121fb7d45593d242c295bc768"
+checksum = "92af95f966d2431f962bc632c2e68eda7777330158bf640c4af4249349b2cdf5"
 dependencies = [
- "quote",
- "syn 1.0.109",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c65e7d70f86d4c0e3b2d585d9bf3f979f0b19d635a336725a88d279f76b939"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite 1.13.0",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6495661273703e7a229356dcbe8c8f38223d697aacfaf0e13590a9ac9977bb52"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -558,7 +557,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel 2.1.1",
+ "async-channel",
  "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.1",
@@ -576,9 +575,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -662,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6100bc57b6209840798d95cb2775684849d332f7bd788db2a8c8caf7ef82a41a"
+checksum = "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -896,7 +895,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "atomicwrites",
  "calloop",
@@ -917,7 +916,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -946,8 +945,8 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.10.0"
-source = "git+https://github.com/pop-os/cosmic-text.git?rev=1b025ae#1b025ae56e0122cff5798b9f54fc56d47a182d2b"
+version = "0.11.1"
+source = "git+https://github.com/pop-os/cosmic-text.git#cb447ea8c6717d558994575b93a00baa549d01f8"
 dependencies = [
  "bitflags 2.4.2",
  "fontdb",
@@ -969,7 +968,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1402,12 +1401,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "event-listener-strategy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.0.0",
  "pin-project-lite",
 ]
 
@@ -1579,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b88c54a38407f7352dd2c4238830115a6377741098ffd1f997c813d0e088a6"
+checksum = "3890d0893c8253d3eb98337af18b3e1a10a9b2958f2a164b53a93fb3a3049e72"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -1909,6 +1929,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 
 [[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.4.2",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck",
+ "proc-macro-crate 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "glyphon"
 version = "0.5.0"
-source = "git+https://github.com/pop-os/glyphon.git?tag=cosmic-0.5-wgpu#db9620f48ceef47e214f3a058b9504e9983ed987"
+source = "git+https://github.com/pop-os/glyphon.git?tag=v0.5.0#1b0646ff8f74da92d3be704dfc2257d7f4d7eed8"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -2024,6 +2081,43 @@ name = "grid"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
+
+[[package]]
+name = "gstreamer"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de95703f4c8e79f4f4e42279cf1ab0e5a46b7ece4a9dfcd16424164af7be9055"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib",
+ "gstreamer-sys",
+ "itertools",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "option-operations",
+ "paste",
+ "pin-project-lite",
+ "pretty-hex",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "564cda782b3e6eed1b81cb4798a06794db56440fb05b422505be689f34ce3bc4"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "gtk-sys"
@@ -2128,7 +2222,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "toml 0.8.10",
+ "toml 0.8.2",
  "unic-langid",
 ]
 
@@ -2191,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2206,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2215,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "bitflags 1.3.2",
  "iced_accessibility",
@@ -2234,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "futures",
  "iced_core",
@@ -2247,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2271,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2283,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2295,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2321,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2331,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2348,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2367,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2496,12 +2590,12 @@ checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "fe8f25ce1159c7740ff0b9b2f5cdf4a8428742ba7c112b9f20f22cd5219c7dab"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.31",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -2629,10 +2723,10 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6ebda94c79a7d349bf5e5eba944d399ac1215106"
+source = "git+https://github.com/pop-os/libcosmic#5738ac20559ff3c327fd9bcf3bcf323281a4c504"
 dependencies = [
  "apply",
- "ashpd 0.6.8",
+ "ashpd",
  "cosmic-client-toolkit",
  "cosmic-config",
  "cosmic-settings-daemon",
@@ -2948,6 +3042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
 name = "mutate_once"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
@@ -3079,19 +3179,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3112,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -3198,6 +3297,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [
+ "paste",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -3510,6 +3618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "pretty-hex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,6 +3631,16 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -3632,9 +3756,9 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "rangemap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
+checksum = "795915a3930a5d6bafd9053d37602fea3e61be2e5d4d788983a8ba9654c1c6f2"
 
 [[package]]
 name = "raw-window-handle"
@@ -3676,9 +3800,9 @@ checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
 
 [[package]]
 name = "read-fonts"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1362980db95801b70031dd592dc052a44b1810ca9da8fbcf7b25983f3174ed0"
+checksum = "d70252c718fb23d41771a4f927e924700edefc2a91ecd52a2ee6f2461d4e6b64"
 dependencies = [
  "font-types",
 ]
@@ -3770,7 +3894,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d8ab342bcc5436e04d3a4c1e09e17d74958bfaddf8d5fad6f85607df0f994f"
 dependencies = [
- "ashpd 0.6.8",
+ "ashpd",
  "block",
  "dispatch",
  "glib-sys",
@@ -4293,7 +4417,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.8.10",
+ "toml 0.8.2",
  "version-compare",
 ]
 
@@ -4511,21 +4635,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.4",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
@@ -4543,9 +4667,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
@@ -4689,9 +4813,9 @@ checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-vo"
@@ -5509,7 +5633,7 @@ name = "xdg-desktop-portal-cosmic"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ashpd 0.7.0",
+ "ashpd",
  "cosmic-bg-config",
  "cosmic-client-toolkit",
  "cosmic-protocols",
@@ -5517,6 +5641,7 @@ dependencies = [
  "env_logger",
  "futures",
  "gbm",
+ "gstreamer",
  "i18n-embed",
  "i18n-embed-fl",
  "image",
@@ -5662,7 +5787,7 @@ version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -5737,7 +5862,7 @@ version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ wgpu = ["libcosmic/wgpu"]
 
 [dependencies]
 anyhow = "1.0.60"
-# ashpd = "0.4.0"
-ashpd = { git = "https://github.com/bilelmoussaoui/ashpd" }
+ashpd = "0.6.8"
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "e65fa5e" }
 cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols", rev = "e65fa5e" }
 futures = "0.3"
@@ -42,5 +41,14 @@ i18n-embed = { version = "0.14.1", features = ["fluent-system", "desktop-request
 i18n-embed-fl = "0.7.0"
 rust-embed = "8.2.0"
 
+[dev-dependencies]
+gst = { package = "gstreamer", version = "0.21.3" }
+
+# [patch."https://github.com/pop-os/libcosmic"]
+# libcosmic = { path = "../libcosmic" }
+# cosmic-config = { path = "../libcosmic/cosmic-config" }
+
+# [patch."https://github.com/smithay/client-toolkit"]
+# smithay-client-toolkit = { path = "../fork/client-toolkit" }
 [profile.release]
 debug = true

--- a/examples/screencast.rs
+++ b/examples/screencast.rs
@@ -1,0 +1,57 @@
+// TODO testing for vaapi, nvenc
+// Test modifiers, when added to pipewire gstreamersrc:
+// - https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1881
+
+use ashpd::desktop::screencast::{CursorMode, PersistMode, Screencast, SourceType};
+use gst::prelude::*;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    gst::init().unwrap();
+
+    let screencast = Screencast::new().await?;
+    let session = screencast.create_session().await?;
+    screencast
+        .select_sources(
+            &session,
+            CursorMode::Embedded,
+            SourceType::Monitor.into(),
+            true,
+            None,
+            PersistMode::DoNot,
+        )
+        .await?;
+    let streams = screencast
+        .start(&session, &ashpd::WindowIdentifier::default())
+        .await?
+        .response()?;
+    println!("{} streams", streams.streams().len());
+    let stream = &streams.streams()[0];
+    let fd = screencast.open_pipe_wire_remote(&session).await?;
+
+    let node_id = stream.pipe_wire_node_id();
+
+    let src = gst::parse_bin_from_description(
+        &format!(
+            "pipewiresrc fd={fd} path={node_id} !
+             capsfilter caps=video/x-raw(memory:DMABuf),format=RGBA"
+        ),
+        true,
+    )?;
+
+    let sink = gst::parse_bin_from_description("waylandsink", true)?;
+    // let sink = gst::parse_bin_from_description("glupload ! glcolorconvert ! video/x-raw(memory:GLMemory),format=NV12 ! gldownload ! video/x-raw(memory:DMABuf) ! vaapih264enc ! h264parse ! mp4mux ! filesink location=out.mp4", true)?;
+    // let sink = gst::parse_bin_from_description("glupload ! video/x-raw(memory:GLMemory) ! nvh264enc ! h264parse ! mp4mux ! filesink location=out.mp4", true)?;
+
+    let pipeline = gst::Pipeline::default()
+        .dynamic_cast::<gst::Pipeline>()
+        .unwrap();
+    pipeline.add_many([&src, &sink])?;
+    gst::Element::link_many([&src, &sink])?;
+
+    pipeline.set_state(gst::State::Playing)?;
+    let bus = pipeline.bus().unwrap();
+    for _msg in bus.iter_timed(gst::ClockTime::NONE) {}
+
+    Ok(())
+}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -31,15 +31,26 @@ pub fn create_dmabuf<T: AsFd>(
     width: u32,
     height: u32,
 ) -> Dmabuf<OwnedFd> {
-    let buffer = device
-        .create_buffer_object_with_modifiers2::<()>(
-            width,
-            height,
-            gbm::Format::Abgr8888,
-            [modifier].into_iter(),
-            gbm::BufferObjectFlags::empty(),
-        )
-        .unwrap();
+    let buffer = if modifier != gbm::Modifier::Invalid {
+        device
+            .create_buffer_object_with_modifiers2::<()>(
+                width,
+                height,
+                gbm::Format::Abgr8888,
+                [modifier].into_iter(),
+                gbm::BufferObjectFlags::empty(),
+            )
+            .unwrap()
+    } else {
+        device
+            .create_buffer_object::<()>(
+                width,
+                height,
+                gbm::Format::Abgr8888,
+                gbm::BufferObjectFlags::empty(),
+            )
+            .unwrap()
+    };
     Dmabuf {
         format: gbm::Format::Abgr8888,
         modifier,

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, unused_variables)]
 
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::{FuturesOrdered, StreamExt};
 use std::{
     collections::HashMap,
     mem,
@@ -160,9 +160,10 @@ impl ScreenCast {
         }
 
         let overlay_cursor = cursor_mode == CURSOR_MODE_EMBEDDED;
-        let mut res_futures = FuturesUnordered::new();
+        // Use `FuturesOrdered` so streams are in consistent order
+        let mut res_futures = FuturesOrdered::new();
         for output in outputs {
-            res_futures.push(ScreencastThread::new(
+            res_futures.push_back(ScreencastThread::new(
                 self.wayland_helper.clone(),
                 output,
                 overlay_cursor,

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -1,7 +1,9 @@
 // Thread to get frames from compositor and redirect to pipewire
 // TODO: Things other than outputs, handle disconnected output, resolution change
+// TODO use `buffer_infos` to determine supported modifiers, formats
 
 // Dmabuf modifier negotiation is described in https://docs.pipewire.org/page_dma_buf.html
+
 
 use pipewire::{
     spa::{
@@ -13,7 +15,7 @@ use pipewire::{
     sys::pw_buffer,
 };
 use std::{
-    io,
+    io, iter,
     os::fd::{BorrowedFd, IntoRawFd},
     slice,
 };
@@ -79,6 +81,45 @@ struct StreamData {
 }
 
 impl StreamData {
+    // Get driver preferred modifier, and plane count
+    fn choose_modifier(&self, modifiers: &[gbm::Modifier]) -> Option<(gbm::Modifier, u32)> {
+        let gbm = self.dmabuf_helper.as_ref().unwrap().gbm().lock().unwrap();
+        if modifiers.iter().all(|x| *x == gbm::Modifier::Invalid) {
+            match gbm.create_buffer_object::<()>(
+                self.width,
+                self.height,
+                gbm::Format::Abgr8888,
+                gbm::BufferObjectFlags::empty(),
+            ) {
+                Ok(bo) => Some((gbm::Modifier::Invalid, bo.plane_count().ok()?)),
+                Err(err) => {
+                    log::error!(
+                        "Failed to choose modifier by creating temporary bo: {}",
+                        err
+                    );
+                    None
+                }
+            }
+        } else {
+            match gbm.create_buffer_object_with_modifiers2::<()>(
+                self.width,
+                self.height,
+                gbm::Format::Abgr8888,
+                modifiers.iter().copied(),
+                gbm::BufferObjectFlags::empty(),
+            ) {
+                Ok(bo) => Some((bo.modifier().ok()?, bo.plane_count().ok()?)),
+                Err(err) => {
+                    log::error!(
+                        "Failed to choose modifier by creating temporary bo: {}",
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+
     fn state_changed(&mut self, stream: &StreamRef, old: StreamState, new: StreamState) {
         log::info!("state-changed '{:?}' -> '{:?}'", old, new);
         match new {
@@ -123,14 +164,22 @@ impl StreamData {
                             default,
                             alternatives
                         );
-                        if let Ok(modifier_val) = gbm::Modifier::try_from(*default as u64) {
-                            self.modifier = modifier_val;
+
+                        // Create temporary bo to get preferred modifier
+                        // Similar to xdg-desktop-portal-wlr
+                        let modifiers = iter::once(default)
+                            .chain(alternatives)
+                            .filter_map(|x| gbm::Modifier::try_from(*x as u64).ok())
+                            .collect::<Vec<_>>();
+                        if let Some((modifier, plane_count)) = self.choose_modifier(&modifiers) {
+                            self.modifier = modifier;
 
                             let params = params(
                                 self.width,
                                 self.height,
+                                plane_count,
                                 self.dmabuf_helper.as_ref(),
-                                Some(modifier_val),
+                                Some(modifier),
                             );
                             let mut params: Vec<_> = params
                                 .iter()
@@ -150,7 +199,6 @@ impl StreamData {
         let datas = unsafe { slice::from_raw_parts_mut(buf.datas, buf.n_datas as usize) };
         // let metas = unsafe { slice::from_raw_parts(buf.metas, buf.n_metas as usize) };
 
-        // TODO test multi-planar
         if datas[0].type_ & (1 << spa_sys::SPA_DATA_DmaBuf) != 0 {
             log::info!("Allocate dmabuf buffer");
             let gbm = self.dmabuf_helper.as_ref().unwrap().gbm().lock().unwrap();
@@ -277,7 +325,7 @@ fn start_stream(
         },
     )?;
 
-    let initial_params = params(width, height, dmabuf_helper.as_ref(), None);
+    let initial_params = params(width, height, 1, dmabuf_helper.as_ref(), None);
     let mut initial_params: Vec<_> = initial_params
         .iter()
         .map(|x| Pod::from_bytes(x.as_slice()).unwrap())
@@ -319,11 +367,12 @@ fn start_stream(
 fn params(
     width: u32,
     height: u32,
+    blocks: u32,
     dmabuf: Option<&DmabufHelper>,
     fixated_modifier: Option<gbm::Modifier>,
 ) -> Vec<Vec<u8>> {
     [
-        Some(buffers(width, height)),
+        Some(buffers(width, height, blocks)),
         fixated_modifier.map(|x| format(width, height, None, Some(x))),
         // Favor dmabuf over shm by listing it first
         dmabuf.map(|x| format(width, height, Some(x), None)),
@@ -341,7 +390,7 @@ fn value_to_bytes(value: pod::Value) -> Vec<u8> {
     bytes
 }
 
-fn buffers(width: u32, height: u32) -> Vec<u8> {
+fn buffers(width: u32, height: u32, blocks: u32) -> Vec<u8> {
     value_to_bytes(pod::Value::Object(pod::Object {
         type_: spa_sys::SPA_TYPE_OBJECT_ParamBuffers,
         id: spa_sys::SPA_PARAM_Buffers,
@@ -375,7 +424,7 @@ fn buffers(width: u32, height: u32) -> Vec<u8> {
             pod::Property {
                 key: spa_sys::SPA_PARAM_BUFFERS_blocks,
                 flags: pod::PropertyFlags::empty(),
-                value: pod::Value::Int(1),
+                value: pod::Value::Int(blocks as i32),
             },
             pod::Property {
                 key: spa_sys::SPA_PARAM_BUFFERS_buffers,

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -246,16 +246,13 @@ fn start_stream(
     wayland_helper: WaylandHelper,
     output: wl_output::WlOutput,
     overlay_cursor: bool,
-) -> Result<
-    (
-        pipewire::main_loop::MainLoop,
-        pipewire::stream::Stream,
-        pipewire::stream::StreamListener<StreamData>,
-        pipewire::context::Context,
-        oneshot::Receiver<anyhow::Result<u32>>,
-    ),
-    pipewire::Error,
-> {
+) -> anyhow::Result<(
+    pipewire::main_loop::MainLoop,
+    pipewire::stream::Stream,
+    pipewire::stream::StreamListener<StreamData>,
+    pipewire::context::Context,
+    oneshot::Receiver<anyhow::Result<u32>>,
+)> {
     let loop_ = pipewire::main_loop::MainLoop::new(None)?;
     let context = pipewire::context::Context::new(&loop_)?;
     let core = context.connect(None)?;
@@ -266,7 +263,7 @@ fn start_stream(
 
     let (width, height) = match wayland_helper.capture_output_shm(&output, overlay_cursor) {
         Some(frame) => (frame.width, frame.height),
-        None => (0, 0), // XXX
+        None => return Err(anyhow::anyhow!("failed to use shm capture to get size")),
     };
 
     let dmabuf_helper = wayland_helper.dmabuf();

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -691,31 +691,36 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for AppData {
     }
 }
 
+fn portal_wayland_socket() -> Option<UnixStream> {
+    let fd = std::env::var("PORTAL_WAYLAND_SOCKET")
+        .ok()?
+        .parse::<RawFd>()
+        .ok()?;
+    env::remove_var("PORTAL_WAYLAND_SOCKET");
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    // set the CLOEXEC flag on this FD
+    let mut flags = rustix::io::fcntl_getfd(&fd).ok()?;
+    flags.insert(rustix::io::FdFlags::CLOEXEC);
+    if let Err(err) = rustix::io::fcntl_setfd(&fd, flags) {
+        drop(fd);
+        log::error!("Failed to set CLOEXEC on portal socket: {}", err);
+        return None;
+    }
+    Some(UnixStream::from(fd))
+}
+
 // Connect to wayland and start task reading events from socket
 pub fn connect_to_wayland() -> wayland_client::Connection {
-    let portal_socket = std::env::var("PORTAL_WAYLAND_SOCKET")
-        .ok()
-        .and_then(|x| x.parse::<RawFd>().ok())
-        .and_then(|fd| {
-            env::remove_var("PORTAL_WAYLAND_SOCKET");
-            let fd = unsafe { OwnedFd::from_raw_fd(fd) };
-            // set the CLOEXEC flag on this FD
-            let mut flags = rustix::io::fcntl_getfd(&fd).ok()?;
-            flags.insert(rustix::io::FdFlags::CLOEXEC);
-            if let Err(err) = rustix::io::fcntl_setfd(&fd, flags) {
-                drop(fd);
-                log::error!("Failed to set CLOEXEC on portal socket: {}", err);
-                return None;
-            } else {
-                Some(UnixStream::from(fd))
-            }
+    if let Some(portal_socket) = portal_wayland_socket() {
+        wayland_client::Connection::from_socket(portal_socket).unwrap_or_else(|err| {
+            log::error!("{}", err);
+            process::exit(1)
         })
-        .expect("Failed to connect to PORTAL_WAYLAND_SOCKET");
-
-    wayland_client::Connection::from_socket(portal_socket).unwrap_or_else(|err| {
-        log::error!("{}", err);
-        process::exit(1)
-    })
+    } else {
+        // Useful fallback for testing and debugging, without `COSMIC_ENABLE_WAYLAND_SECURITY`
+        log::warn!("Failed to find `PORTAL_WAYLAND_SOCKET`; trying default Wayland display");
+        wayland_client::Connection::connect_to_env().unwrap()
+    }
 }
 
 fn gbm_device(rdev: u64) -> io::Result<Option<gbm::Device<fs::File>>> {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -584,6 +584,7 @@ impl ScreencopyHandler for AppData {
         Session::for_session(session).unwrap().update(|data| {
             data.res = Some(Ok(()));
         });
+        session.destroy();
     }
 
     fn failed(
@@ -597,6 +598,7 @@ impl ScreencopyHandler for AppData {
         Session::for_session(session).unwrap().update(|data| {
             data.res = Some(Err(reason));
         });
+        session.destroy();
     }
 }
 


### PR DESCRIPTION
I have an example that uses ashpd/gstreamer to get dmabufs from the pipewire stream. This could be expanded to take arguments to test different kinds of capture, using different GPUs, etc.

It works fine capturing an Intel output to a gstreamer `waylandsink` window, where Intel is the `main_device`. I can't seem to get vaapi or nvenc h264 encoding to work here (with different errors). When being careful to avoid copy to CPU.

Capturing the Nvidia output seems to fail here (xdg-desktop-portal cosmic is currently using dmabufs allocated with the `main_device` regardless of capture source). When I ran `wayland-1-renderD129 xdg-desktop-portal-cosmic` to capture with the Nvidia GPU, the compositor completely froze...

Anyway, this should be helpful for testing and improving xdg-desktop-portal-cosmic and cosmic-comp. I still need to test this with https://github.com/pop-os/cosmic-comp/pull/278. Though also, xdg-desktop-portal-cosmic (unlike cosmic-workspaces) isn't currently passing the node id to `screencopy_session.attach_buffer`.