### PR TITLE
Remove unnecessary slashes in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ $(BIN): Cargo.toml Cargo.lock src/main.rs vendor-check
 
 install:
 	install -Dm0755 target/$(TARGET)/$(BIN) $(DESTDIR)$(libexecdir)/$(BIN)
-	install -Dm0644 data/$(DBUS_NAME).service $(DESTDIR)/$(datadir)/dbus-1/services/$(DBUS_NAME).service
-	install -Dm0644 data/cosmic.portal $(DESTDIR)/$(datadir)/xdg-desktop-portal/portals/cosmic.portal
-	install -Dm0644 data/cosmic-portals.conf $(DESTDIR)/$(datadir)/xdg-desktop-portal/cosmic-portals.conf
+	install -Dm0644 data/$(DBUS_NAME).service $(DESTDIR)$(datadir)/dbus-1/services/$(DBUS_NAME).service
+	install -Dm0644 data/cosmic.portal $(DESTDIR)$(datadir)/xdg-desktop-portal/portals/cosmic.portal
+	install -Dm0644 data/cosmic-portals.conf $(DESTDIR)$(datadir)/xdg-desktop-portal/cosmic-portals.conf
 	find 'data'/'icons' -type f -exec echo {} \; \
 		| rev \
 		| cut -d'/' -f-3 \


### PR DESCRIPTION
This PR removes some slashes in the makefile that I believe may be messing up my rpm builds. It's possible the issue is something else but nevertheless we can remove the unnecessary slashes.

![image](https://github.com/pop-os/xdg-desktop-portal-cosmic/assets/56272643/af96e191-cf0b-4c3f-9f2f-3981a1913377)
