### PR TITLE
Don't create new screencopy session or wl_buffer each frame

### DIFF
--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -4,7 +4,6 @@
 
 // Dmabuf modifier negotiation is described in https://docs.pipewire.org/page_dma_buf.html
 
-
 use pipewire::{
     spa::{
         self,
@@ -266,8 +265,8 @@ impl StreamData {
                         })
                         .collect(),
                 };
-                self.wayland_helper.capture_output_dmabuf_fd(
-                    &self.output,
+                self.wayland_helper.capture_source_dmabuf_fd(
+                    CaptureSource::Output(&self.output),
                     self.overlay_cursor,
                     &dmabuf,
                 );

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -18,7 +18,7 @@ use wayland_client::protocol::wl_output::{self, WlOutput};
 use zbus::zvariant;
 
 use crate::app::{CosmicPortal, OutputState};
-use crate::wayland::WaylandHelper;
+use crate::wayland::{CaptureSource, WaylandHelper};
 use crate::widget::rectangle_selection::DragState;
 use crate::{fl, subscription, PortalResponse};
 
@@ -141,7 +141,7 @@ impl Screenshot {
         let mut map = HashMap::with_capacity(outputs.len());
         for (output, _, name) in outputs {
             let frame = wayland_helper
-                .capture_output_shm(&output, false)
+                .capture_source_shm(CaptureSource::Output(&output), false)
                 .ok_or_else(|| anyhow::anyhow!("shm screencopy failed"))?;
             map.insert(name, Arc::new(frame.image()?));
         }
@@ -194,7 +194,7 @@ impl Screenshot {
             let mut frames = Vec::with_capacity(outputs.len());
             for (output, (output_x, output_y), _) in outputs {
                 let frame = wayland_helper
-                    .capture_output_shm(&output, false)
+                    .capture_source_shm(CaptureSource::Output(&output), false)
                     .ok_or_else(|| anyhow::anyhow!("shm screencopy failed"))?;
                 let rect = Rect {
                     left: output_x,


### PR DESCRIPTION
This shouldn't change behavior, except that `WAYLAND_DEBUG=1` will show a lot fewer Wayland requests while capturing the screen. And perhaps some performance benefit, but I haven't specifically verified that.

The changes to how screencopy is handled should help for moving to the v2 screencopy protocol (https://github.com/pop-os/cosmic-protocols/pull/24).