### PR TITLE
Fix passing fd to pipewire in example.

### DIFF
--- a/examples/screencast.rs
+++ b/examples/screencast.rs
@@ -5,6 +5,8 @@
 use ashpd::desktop::screencast::{CursorMode, PersistMode, Screencast, SourceType};
 use gst::prelude::*;
 
+use std::os::fd::AsRawFd;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     gst::init().unwrap();
@@ -33,8 +35,9 @@ async fn main() -> anyhow::Result<()> {
 
     let src = gst::parse_bin_from_description(
         &format!(
-            "pipewiresrc fd={fd:?} path={node_id} !
-             capsfilter caps=video/x-raw(memory:DMABuf),format=RGBA"
+            "pipewiresrc fd={} path={node_id} !
+             capsfilter caps=video/x-raw(memory:DMABuf),format=RGBA",
+             fd.as_raw_fd()
         ),
         true,
     )?;


### PR DESCRIPTION
[This](https://github.com/pop-os/xdg-desktop-portal-cosmic/commit/ddafa7b4506673abb8b219d1f8016ea87b3badb8#diff-8cd8df4f536f3b7978164bd2953e645b6f45b81e6fb552ffb3616e3cca74478b) change is incorrect, as `Debug` is implemented as `"OwnedFd({fd})"` (meaning `"fd={fd:?}"` becomes `"fd=OwnedFd(##)"`.

On a related note, I can't get the example to work, neither in Gnome, nor in COSMIC (both on ArchLinux). In both cases I get:

```
Error: Failed to link elements 'bin0' and 'bin1'
```

Interestingly in Gnome I get a dialog for choosing what to cast, but not in COSMIC. Perhaps this is not implemented yet, but I thought it was worth mentioning. If I set the sink to `filesink location=out.bin` I get `"Error: Element failed to change its state"`, which has got me a bit stumped (`GST_DEBUG` also show `no such pad 'sink' in element "pipewiresrc0"`). Let me know if this is more of a `ashpd` issue though.

Apologies if I am doing something clearly wrong, I have only started using xdg-desktop-portal and gstreamer since yesterday :).