### PR TITLE
feat: Restore last used screenshot settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmic-portal-config"
+version = "0.1.0"
+dependencies = [
+ "cosmic-config",
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/cosmic-protocols?rev=c8d3a1c#c8d3a1c3d40d16235f4720969a54ed570ec7a976"
@@ -7048,7 +7057,9 @@ dependencies = [
  "ashpd",
  "cosmic-bg-config",
  "cosmic-client-toolkit",
+ "cosmic-config",
  "cosmic-files",
+ "cosmic-portal-config",
  "cosmic-protocols",
  "dirs",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,10 @@ i18n-embed = { version = "0.14.1", features = [
 i18n-embed-fl = "0.8.0"
 rust-embed = "8.2.0"
 
+# Workspace
+cosmic-config.workspace = true
 log.workspace = true
 serde.workspace = true
-cosmic-config.workspace = true
 
 [workspace.dependencies]
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
@@ -69,7 +70,6 @@ serde = "1.0.143"
 
 [dev-dependencies]
 gst = { package = "gstreamer", version = "0.21.3" }
-
 
 # [patch."https://github.com/pop-os/libcosmic"]
 # libcosmic = { path = "../libcosmic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "GPL-3.0-or-later"
 default = []
 wgpu = ["libcosmic/wgpu"]
 
+[workspace]
+members = ["cosmic-portal-config"]
+
 [dependencies]
 anyhow = "1.0.60"
 ashpd = "0.8.1"
@@ -22,6 +25,7 @@ libcosmic = { git = "https://github.com/pop-os/libcosmic", features = [
     "dbus-config",
 ] }
 cosmic-bg-config = { git = "https://github.com/pop-os/cosmic-bg" }
+cosmic-portal-config = { path = "./cosmic-portal-config" }
 memmap2 = "0.9.0"
 # pipewire = { git = "https://github.com/pop-os/pipewire-rs" }
 once_cell = "1.19.0"
@@ -30,7 +34,6 @@ pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", featur
 ] }
 png = "0.17.5"
 rustix = { version = "0.38.0", features = ["fs"] }
-serde = "1.0.143"
 # spa_sys = { package = "libspa-sys", git = "https://github.com/pop-os/pipewire-rs" }
 spa_sys = { package = "libspa-sys", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
 tempfile = "3.5.0"
@@ -40,7 +43,6 @@ zbus = { version = "4.2.2", default-features = false, features = ["tokio"] }
 gbm = "0.15.0"
 wayland-protocols = "0.32.1"
 env_logger = "0.11.3"
-log = "0.4.20"
 dirs = "5.0.1"
 time = { version = "0.3.31", features = [
     "local-offset",
@@ -56,8 +58,18 @@ i18n-embed = { version = "0.14.1", features = [
 i18n-embed-fl = "0.8.0"
 rust-embed = "8.2.0"
 
+log.workspace = true
+serde.workspace = true
+cosmic-config.workspace = true
+
+[workspace.dependencies]
+cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
+log = "0.4.20"
+serde = "1.0.143"
+
 [dev-dependencies]
 gst = { package = "gstreamer", version = "0.21.3" }
+
 
 # [patch."https://github.com/pop-os/libcosmic"]
 # libcosmic = { path = "../libcosmic" }

--- a/cosmic-portal-config/Cargo.toml
+++ b/cosmic-portal-config/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cosmic-portal-config"
+version = "0.1.0"
+edition = "2021"
+description = "Configuration for COSMIC's XDG portal backend"
+repository = "https://github.com/pop-os/xdg-desktop-portal-cosmic"
+license = "GPL-3.0-or-later"
+
+[dependencies]
+cosmic-config.workspace = true
+log.workspace = true
+
+[dependencies.serde]
+features = ["derive"]
+workspace = true

--- a/cosmic-portal-config/src/lib.rs
+++ b/cosmic-portal-config/src/lib.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pub mod screenshot;
+
+use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
+use serde::{Deserialize, Serialize};
+
+use screenshot::Screenshot;
+
+pub const APP_ID: &str = "com.system76.CosmicPortal";
+pub const CONFIG_VERSION: u64 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[version = 1]
+#[id = "com.system76.CosmicPortal"]
+pub struct Config {
+    /// Interactive screenshot settings
+    pub screenshot: Screenshot,
+}
+
+impl Config {
+    pub fn load() -> (Self, Option<cosmic_config::Config>) {
+        match cosmic_config::Config::new(APP_ID, CONFIG_VERSION) {
+            Ok(handler) => {
+                let config = Config::get_entry(&handler)
+                    .inspect_err(|(errors, _)| {
+                        for err in errors {
+                            log::error!("{err}")
+                        }
+                    })
+                    .unwrap_or_else(|(_, config)| config);
+                (config, Some(handler))
+            }
+            Err(e) => {
+                log::error!("Failed to get settings for `{APP_ID}` (v {CONFIG_VERSION}): {e}");
+                (Config::default(), None)
+            }
+        }
+    }
+}

--- a/cosmic-portal-config/src/screenshot.rs
+++ b/cosmic-portal-config/src/screenshot.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Screenshot {
+    pub save_location: ImageSaveLocation,
+    pub choice: Choice,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ImageSaveLocation {
+    Clipboard,
+    #[default]
+    Pictures,
+    Documents,
+    // Custom(PathBuf), // TODO
+}
+
+// TODO: Use type from screenshot directly?
+#[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize)]
+pub enum Choice {
+    #[default]
+    Output,
+    Rectangle,
+    Window,
+}

--- a/cosmic-portal-config/src/screenshot.rs
+++ b/cosmic-portal-config/src/screenshot.rs
@@ -12,6 +12,7 @@ pub struct Screenshot {
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub enum ImageSaveLocation {
     Clipboard,
     #[default]
@@ -21,10 +22,28 @@ pub enum ImageSaveLocation {
 }
 
 // TODO: Use type from screenshot directly?
-#[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub enum Choice {
-    #[default]
-    Output,
+    Output(Option<String>),
     Rectangle,
     Window,
+}
+
+impl From<&mut Choice> for Choice {
+    fn from(value: &mut Choice) -> Self {
+        // Convenience implementation to move Choice so that the borrow checker doesn't complain
+        // about partial moves
+        match value {
+            Choice::Output(output) => Choice::Output(output.take()),
+            Choice::Rectangle => Choice::Rectangle,
+            Choice::Window => Choice::Window,
+        }
+    }
+}
+
+impl Default for Choice {
+    fn default() -> Self {
+        Choice::Output(None)
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,4 @@
-use crate::{
-    access, cosmic_portal_config as portal_config, file_chooser, fl, screenshot, subscription,
-};
+use crate::{access, config, file_chooser, fl, screenshot, subscription};
 use cosmic::iced::keyboard;
 use cosmic::iced_core::event::wayland::OutputEvent;
 use cosmic::iced_core::keyboard::key::Named;
@@ -18,7 +16,7 @@ pub(crate) fn run() -> cosmic::iced::Result {
     let settings = cosmic::app::Settings::default()
         .no_main_window(true)
         .exit_on_close(false);
-    let (config, config_handler) = portal_config::Config::load();
+    let (config, config_handler) = config::Config::load();
     let flags = Flags {
         config,
         config_handler,
@@ -32,7 +30,7 @@ pub struct CosmicPortal {
     pub tx: Option<tokio::sync::mpsc::Sender<subscription::Event>>,
 
     pub config_handler: Option<cosmic_config::Config>,
-    pub config: cosmic_portal_config::Config,
+    pub config: config::Config,
 
     pub access_args: Option<access::AccessDialogArgs>,
     pub access_choices: Vec<(Option<usize>, Vec<String>)>,
@@ -66,15 +64,15 @@ pub enum Msg {
     Screenshot(screenshot::Msg),
     Portal(subscription::Event),
     Output(OutputEvent, WlOutput),
-    ConfigSetScreenshot(portal_config::screenshot::Screenshot),
+    ConfigSetScreenshot(config::screenshot::Screenshot),
     /// Update config from external changes
-    ConfigSubUpdate(portal_config::Config),
+    ConfigSubUpdate(config::Config),
 }
 
 #[derive(Clone, Debug)]
 pub struct Flags {
     pub config_handler: Option<cosmic_config::Config>,
-    pub config: portal_config::Config,
+    pub config: config::Config,
 }
 
 impl cosmic::Application for CosmicPortal {
@@ -107,15 +105,15 @@ impl cosmic::Application for CosmicPortal {
             vec![
                 (
                     fl!("save-to", "clipboard"),
-                    portal_config::screenshot::ImageSaveLocation::Clipboard,
+                    config::screenshot::ImageSaveLocation::Clipboard,
                 ),
                 (
                     fl!("save-to", "pictures"),
-                    portal_config::screenshot::ImageSaveLocation::Pictures,
+                    config::screenshot::ImageSaveLocation::Pictures,
                 ),
                 (
                     fl!("save-to", "documents"),
-                    portal_config::screenshot::ImageSaveLocation::Documents,
+                    config::screenshot::ImageSaveLocation::Documents,
                 ),
             ],
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use cosmic::cosmic_theme::palette::Srgba;
 use std::collections::HashMap;
 use zbus::zvariant::{self, OwnedValue};
 
+pub use cosmic_portal_config;
+
 mod access;
 mod app;
 mod buffer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use cosmic::cosmic_theme::palette::Srgba;
 use std::collections::HashMap;
 use zbus::zvariant::{self, OwnedValue};
 
-pub use cosmic_portal_config;
+pub use cosmic_portal_config as config;
 
 mod access;
 mod app;

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -11,9 +11,9 @@ use tokio::sync::mpsc::Receiver;
 use zbus::{zvariant, Connection};
 
 use crate::{
-    access::Access, file_chooser::FileChooser, screencast::ScreenCast, screenshot::Screenshot,
-    wayland, ColorScheme, Contrast, Settings, ACCENT_COLOR_KEY, APPEARANCE_NAMESPACE,
-    COLOR_SCHEME_KEY, CONTRAST_KEY, DBUS_NAME, DBUS_PATH,
+    access::Access, config, file_chooser::FileChooser, screencast::ScreenCast,
+    screenshot::Screenshot, wayland, ColorScheme, Contrast, Settings, ACCENT_COLOR_KEY,
+    APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY, CONTRAST_KEY, DBUS_NAME, DBUS_PATH,
 };
 
 #[derive(Clone)]
@@ -24,7 +24,7 @@ pub enum Event {
     Accent(Srgba),
     IsDark(bool),
     HighContrast(bool),
-    Config(cosmic_portal_config::Config),
+    Config(config::Config),
     Init(tokio::sync::mpsc::Sender<Event>),
 }
 
@@ -107,8 +107,8 @@ pub(crate) fn portal_subscription(
         ),
         cosmic_config::config_subscription(
             TypeId::of::<ConfigSubscription>(),
-            cosmic_portal_config::APP_ID.into(),
-            cosmic_portal_config::CONFIG_VERSION,
+            config::APP_ID.into(),
+            config::CONFIG_VERSION,
         )
         .map(|update| {
             for error in update.errors {


### PR DESCRIPTION
Closes: pop-os/cosmic-screenshot#29

I tend to reuse the same screenshot settings much like the users in the linked issue. Currently, the portal uses a reasonable default, but it would be ideal to restore the last used options.

This patch implements the plumbing for configs as well as adds a config for the screenshot endpoint. It currently works, but I have to rebase the patch on master and support saving the selected output. The latter is a planned feature as per a comment in `screenshot.rs`.

The plumbing for configs should be useful in the future as well since there will likely be other settings to store for different endpoints.

### To do:
- [x] Rebase on master
- [x] Store last selected output

### Updates:
- Force pushed to remove a finished to do and an unneeded clone