### PR TITLE
feat: implement enter to confirm capture

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -250,6 +250,12 @@ impl cosmic::Application for CosmicPortal {
                         ..
                     },
                 ) => Some(Msg::Screenshot(screenshot::Msg::Cancel)),
+                cosmic::iced_core::Event::Keyboard(
+                    cosmic::iced_core::keyboard::Event::KeyPressed {
+                        key: keyboard::Key::Named(Named::Enter),
+                        ..
+                    },
+                ) => Some(Msg::Screenshot(screenshot::Msg::Capture)),
                 _ => None,
             }),
         ];


### PR DESCRIPTION
Implements executing screenshot capture when the enter button is pressed.

Closes https://github.com/pop-os/cosmic-screenshot/issues/35