### PR TITLE
Screencast dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2416,15 +2416,15 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gio-sys"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+checksum = "e4feb96b31c32730ea3e1e89aecd2e4e37ecb1c473ad8f685e3430a159419f63"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
- "winapi",
+ "system-deps 7.0.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2446,9 +2446,9 @@ checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 
 [[package]]
 name = "glib"
-version = "0.18.5"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+checksum = "fee90a615ce05be7a32932cfb8adf2c4bbb4700e80d37713c981fb24c0c56238"
 dependencies = [
  "bitflags 2.6.0",
  "futures-channel",
@@ -2462,20 +2462,18 @@ dependencies = [
  "gobject-sys",
  "libc",
  "memchr",
- "once_cell",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.18.5"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+checksum = "4da558d8177c0c8c54368818b508a4244e1286fce2858cef4e547023f0cfa5ef"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-crate 2.0.0",
- "proc-macro-error",
+ "heck 0.5.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -2483,12 +2481,12 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+checksum = "4958c26e5a01c9af00dea669a97369eccbec29a8e6d125c24ea2d85ee7467b60"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 7.0.1",
 ]
 
 [[package]]
@@ -2544,13 +2542,13 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+checksum = "c6908864f5ffff15b56df7e90346863904f49b949337ed0456b9287af61903b8"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 7.0.1",
 ]
 
 [[package]]
@@ -2613,9 +2611,9 @@ checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
 
 [[package]]
 name = "gstreamer"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de95703f4c8e79f4f4e42279cf1ab0e5a46b7ece4a9dfcd16424164af7be9055"
+checksum = "21e95b1d1153239a621ec143501fdcca6c1ad3efb87d268597285f85c4136f73"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -2623,29 +2621,29 @@ dependencies = [
  "futures-util",
  "glib",
  "gstreamer-sys",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "muldiv",
  "num-integer",
  "num-rational",
+ "once_cell",
  "option-operations",
  "paste",
  "pin-project-lite",
- "pretty-hex",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.21.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564cda782b3e6eed1b81cb4798a06794db56440fb05b422505be689f34ce3bc4"
+checksum = "d9c9005b55dd2b1784645963c1ec409f9d420a56f6348d0ae69c2eaff584bcc3"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 7.0.1",
 ]
 
 [[package]]
@@ -2976,7 +2974,7 @@ dependencies = [
  "iced_graphics",
  "iced_runtime",
  "iced_style",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "raw-window-handle",
  "smithay-client-toolkit 0.19.1",
@@ -3317,6 +3315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,7 +3600,7 @@ dependencies = [
  "libspa-sys",
  "nix 0.27.1",
  "nom 7.1.3",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3603,7 +3610,7 @@ source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs#2ad12181ffc02c
 dependencies = [
  "bindgen",
  "cc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4529,7 +4536,7 @@ source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs#2ad12181ffc02c
 dependencies = [
  "bindgen",
  "libspa-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4607,12 +4614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "pretty-hex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,15 +4621,6 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -4787,7 +4779,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.12.1",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -4802,7 +4794,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "simd_helpers",
- "system-deps",
+ "system-deps 6.2.2",
  "thiserror",
  "v_frame",
  "wasm-bindgen",
@@ -5584,6 +5576,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c81f13d9a334a6c242465140bd262fae382b752ff2011c4f7419919a9c97922"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.14",
+ "version-compare",
+]
+
+[[package]]
 name = "taffy"
 version = "0.3.11"
 source = "git+https://github.com/DioxusLabs/taffy?rev=7781c70#7781c70241f7f572130c13106f2a869a9cf80885"
@@ -5833,17 +5838,6 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
 name = "clipboard-win"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7049,6 +7089,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ashpd",
+ "clap",
  "cosmic-bg-config",
  "cosmic-client-toolkit",
  "cosmic-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
  "calloop 0.14.0",
  "cosmic-config-derive",
  "cosmic-settings-daemon",
- "dirs",
+ "dirs 5.0.1",
  "futures-util",
  "iced_futures",
  "known-folders",
@@ -1363,7 +1363,7 @@ version = "0.1.0"
 source = "git+https://github.com/pop-os/cosmic-files#66cef478ba76b00efe19232d4dc528e609a2115f"
 dependencies = [
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "fork",
  "fs_extra",
@@ -1456,7 +1456,7 @@ dependencies = [
  "almost",
  "cosmic-config",
  "csscolorparser",
- "dirs",
+ "dirs 5.0.1",
  "lazy_static",
  "palette",
  "ron",
@@ -1669,11 +1669,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1684,6 +1693,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2228,12 +2248,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "freedesktop-desktop-entry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c201444ddafb5506fe85265b48421664ff4617e3b7090ef99e42a0070c1aead0"
+dependencies = [
+ "dirs 3.0.2",
+ "gettext-rs",
+ "memchr",
+ "thiserror",
+ "xdg",
+]
+
+[[package]]
+name = "freedesktop-desktop-entry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714dc75515835140c365a1f199143577afe4650ef1277f2fba50032c8c20bbc2"
+dependencies = [
+ "dirs 5.0.1",
+ "gettext-rs",
+ "log",
+ "memchr",
+ "strsim 0.11.1",
+ "textdistance",
+ "thiserror",
+ "xdg",
+]
+
+[[package]]
 name = "freedesktop-icons"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ef34245e0540c9a3ce7a28340b98d2c12b75da0d446da4e8224923fcaa0c16"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
  "once_cell",
  "rust-ini",
  "thiserror",
@@ -2426,6 +2475,26 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gettext-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49ea8a8fad198aaa1f9655a2524b64b70eb06b2f3ff37da407566c93054f364"
+dependencies = [
+ "gettext-sys",
+ "locale_config",
+]
+
+[[package]]
+name = "gettext-sys"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63ce2e00f56a206778276704bbe38564c8695249fdc8f354b4ef71c57c3839d"
+dependencies = [
+ "cc",
+ "temp-dir",
 ]
 
 [[package]]
@@ -3543,6 +3612,7 @@ dependencies = [
  "css-color",
  "derive_setters",
  "fraction",
+ "freedesktop-desktop-entry 0.5.2",
  "freedesktop-icons",
  "iced",
  "iced_accessibility",
@@ -3556,11 +3626,15 @@ dependencies = [
  "iced_wgpu",
  "iced_widget",
  "lazy_static",
+ "mime 0.3.17",
+ "nix 0.27.1",
  "palette",
  "rfd",
  "serde",
+ "shlex",
  "slotmap",
  "taffy",
+ "textdistance",
  "thiserror",
  "tokio",
  "tracing",
@@ -5646,6 +5720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "temp-dir"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5665,6 +5745,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textdistance"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d321c8576c2b47e43953e9cce236550d4cd6af0a6ce518fe084340082ca6037b"
 
 [[package]]
 name = "thiserror"
@@ -7096,8 +7182,9 @@ dependencies = [
  "cosmic-files",
  "cosmic-portal-config",
  "cosmic-protocols",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
+ "freedesktop-desktop-entry 0.7.0",
  "futures",
  "gbm",
  "gstreamer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols", re
 futures = "0.3"
 image = "0.25"
 libcosmic = { git = "https://github.com/pop-os/libcosmic", features = [
+    "desktop",
     "wayland",
     "tokio",
     "dbus-config",
@@ -62,6 +63,7 @@ rust-embed = "8.2.0"
 cosmic-config.workspace = true
 log.workspace = true
 serde.workspace = true
+freedesktop-desktop-entry = "0.7.0"
 
 [workspace.dependencies]
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ serde = "1.0.143"
 
 [dev-dependencies]
 gst = { package = "gstreamer", version = "0.23.0" }
-
+clap = { version = "4.5.9", features = ["derive"] }
 
 # [patch."https://github.com/pop-os/libcosmic"]
 # libcosmic = { path = "../libcosmic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,8 @@ log = "0.4.20"
 serde = "1.0.143"
 
 [dev-dependencies]
-gst = { package = "gstreamer", version = "0.21.3" }
+gst = { package = "gstreamer", version = "0.23.0" }
+
 
 # [patch."https://github.com/pop-os/libcosmic"]
 # libcosmic = { path = "../libcosmic" }

--- a/examples/screencast.rs
+++ b/examples/screencast.rs
@@ -33,11 +33,20 @@ async fn main() -> anyhow::Result<()> {
 
     let node_id = stream.pipe_wire_node_id();
 
+    // TODO Set drm-format; gstreamer Wayland plugins may still be missing some
+    // needed support
+    let format = if gst::version() > (1, 24, 0, 0) {
+        "DMA_DRM"
+    } else {
+        "RGBA"
+    };
+
     let src = gst::parse::bin_from_description(
         &format!(
             "pipewiresrc fd={} path={node_id} !
-             capsfilter caps=video/x-raw(memory:DMABuf),format=RGBA",
-            fd.as_raw_fd()
+             capsfilter caps=video/x-raw(memory:DMABuf),format={}",
+            fd.as_raw_fd(),
+            format
         ),
         true,
     )?;

--- a/examples/screencast.rs
+++ b/examples/screencast.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
 
     let node_id = stream.pipe_wire_node_id();
 
-    let src = gst::parse_bin_from_description(
+    let src = gst::parse::bin_from_description(
         &format!(
             "pipewiresrc fd={} path={node_id} !
              capsfilter caps=video/x-raw(memory:DMABuf),format=RGBA",
@@ -42,9 +42,9 @@ async fn main() -> anyhow::Result<()> {
         true,
     )?;
 
-    let sink = gst::parse_bin_from_description("waylandsink", true)?;
-    // let sink = gst::parse_bin_from_description("glupload ! glcolorconvert ! video/x-raw(memory:GLMemory),format=NV12 ! gldownload ! video/x-raw(memory:DMABuf) ! vaapih264enc ! h264parse ! mp4mux ! filesink location=out.mp4", true)?;
-    // let sink = gst::parse_bin_from_description("glupload ! video/x-raw(memory:GLMemory) ! nvh264enc ! h264parse ! mp4mux ! filesink location=out.mp4", true)?;
+    let sink = gst::parse::bin_from_description("waylandsink", true)?;
+    // let sink = gst::parse::bin_from_description("glupload ! glcolorconvert ! video/x-raw(memory:GLMemory),format=NV12 ! gldownload ! video/x-raw(memory:DMABuf) ! vaapih264enc ! h264parse ! mp4mux ! filesink location=out.mp4", true)?;
+    // let sink = gst::parse::bin_from_description("glupload ! video/x-raw(memory:GLMemory) ! nvh264enc ! h264parse ! mp4mux ! filesink location=out.mp4", true)?;
 
     let pipeline = gst::Pipeline::default()
         .dynamic_cast::<gst::Pipeline>()

--- a/i18n/en/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/en/xdg_desktop_portal_cosmic.ftl
@@ -1,8 +1,11 @@
 allow = Allow
 cancel = Cancel
 capture = Capture
+share = Share
 save-to = Save to
     .clipboard = { save-to } Clipboard
     .pictures = { save-to } Pictures
     .documents = { save-to } Documents
 choose-folder = Choose folder
+
+share-screen = Share your screen

--- a/i18n/en/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/en/xdg_desktop_portal_cosmic.ftl
@@ -9,3 +9,7 @@ save-to = Save to
 choose-folder = Choose folder
 
 share-screen = Share your screen
+    .description = The system wants to share the contents of your screen with "{$app_name}". Select a screen or window to share.
+unknown-application = Unknown Application
+output = Output
+window = Window

--- a/src/app.rs
+++ b/src/app.rs
@@ -302,7 +302,7 @@ impl cosmic::Application for CosmicPortal {
                         key: keyboard::Key::Named(Named::Escape),
                         ..
                     },
-                ) => Some(Msg::Screenshot(screenshot::Msg::Cancel)),
+                ) => Some(Msg::Screenshot(screenshot::Msg::Cancel)), // XXX
                 cosmic::iced_core::Event::Keyboard(
                     cosmic::iced_core::keyboard::Event::KeyPressed {
                         key: keyboard::Key::Named(Named::Enter),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
-use crate::{access, config, file_chooser, fl, screenshot, subscription};
+use crate::{access, config, file_chooser, fl, screencast_dialog, screenshot, subscription};
 use cosmic::iced::keyboard;
 use cosmic::iced_core::event::wayland::OutputEvent;
 use cosmic::iced_core::keyboard::key::Named;
-use cosmic::widget::dropdown;
+use cosmic::widget::{self, dropdown};
 use cosmic::Command;
 use cosmic::{
     app, cosmic_config,
@@ -38,6 +38,9 @@ pub struct CosmicPortal {
     pub file_choosers: HashMap<window::Id, (file_chooser::Args, file_chooser::Dialog)>,
 
     pub screenshot_args: Option<screenshot::Args>,
+    pub screencast_args: Option<screencast_dialog::Args>,
+    pub screencast_tab_model:
+        widget::segmented_button::Model<widget::segmented_button::SingleSelect>,
     pub location_options: Vec<String>,
     pub prev_rectangle: Option<screenshot::Rect>,
     pub wayland_helper: crate::wayland::WaylandHelper,
@@ -62,6 +65,7 @@ pub enum Msg {
     Access(access::Msg),
     FileChooser(window::Id, file_chooser::Msg),
     Screenshot(screenshot::Msg),
+    Screencast(screencast_dialog::Msg),
     Portal(subscription::Event),
     Output(OutputEvent, WlOutput),
     ConfigSetScreenshot(config::screenshot::Screenshot),
@@ -129,6 +133,8 @@ impl cosmic::Application for CosmicPortal {
                 access_choices: Default::default(),
                 file_choosers: Default::default(),
                 screenshot_args: Default::default(),
+                screencast_args: Default::default(),
+                screencast_tab_model: Default::default(),
                 location_options: Vec::new(),
                 prev_rectangle: Default::default(),
                 outputs: Default::default(),
@@ -147,6 +153,8 @@ impl cosmic::Application for CosmicPortal {
     fn view_window(&self, id: window::Id) -> cosmic::prelude::Element<Self::Message> {
         if id == *access::ACCESS_ID {
             access::view(self).map(Msg::Access)
+        } else if id == *screencast_dialog::SCREENCAST_ID {
+            screencast_dialog::view(self).map(Msg::Screencast)
         } else if self.outputs.iter().any(|o| o.id == id) {
             screenshot::view(self, id).map(Msg::Screenshot)
         } else {
@@ -169,6 +177,9 @@ impl cosmic::Application for CosmicPortal {
                 subscription::Event::Screenshot(args) => {
                     screenshot::update_args(self, args).map(cosmic::app::Message::App)
                 }
+                subscription::Event::Screencast(args) => {
+                    screencast_dialog::update_args(self, args).map(cosmic::app::Message::App)
+                }
                 subscription::Event::Config(config) => self.update(Msg::ConfigSubUpdate(config)),
                 subscription::Event::Accent(_)
                 | subscription::Event::IsDark(_)
@@ -179,6 +190,9 @@ impl cosmic::Application for CosmicPortal {
                 }
             },
             Msg::Screenshot(m) => screenshot::update_msg(self, m).map(cosmic::app::Message::App),
+            Msg::Screencast(m) => {
+                screencast_dialog::update_msg(self, m).map(cosmic::app::Message::App)
+            }
             Msg::Output(o_event, wl_output) => {
                 match o_event {
                     OutputEvent::Created(Some(info))

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 use crate::{access, config, file_chooser, fl, screencast_dialog, screenshot, subscription};
-use cosmic::iced::keyboard;
 use cosmic::iced_core::event::wayland::OutputEvent;
 use cosmic::iced_core::keyboard::key::Named;
 use cosmic::widget::{self, dropdown};
@@ -297,18 +296,6 @@ impl cosmic::Application for CosmicPortal {
                     }
                     _ => None,
                 },
-                cosmic::iced_core::Event::Keyboard(
-                    cosmic::iced_core::keyboard::Event::KeyPressed {
-                        key: keyboard::Key::Named(Named::Escape),
-                        ..
-                    },
-                ) => Some(Msg::Screenshot(screenshot::Msg::Cancel)), // XXX
-                cosmic::iced_core::Event::Keyboard(
-                    cosmic::iced_core::keyboard::Event::KeyPressed {
-                        key: keyboard::Key::Named(Named::Enter),
-                        ..
-                    },
-                ) => Some(Msg::Screenshot(screenshot::Msg::Capture)),
                 _ => None,
             }),
         ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod documents;
 mod file_chooser;
 mod localize;
 mod screencast;
+mod screencast_dialog;
 mod screencast_thread;
 mod screenshot;
 mod subscription;

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -170,6 +170,7 @@ impl ScreenCast {
         let toplevels = self.wayland_helper.toplevels();
         let Some(capture_sources) = screencast_dialog::show_screencast_prompt(
             &self.tx,
+            app_id,
             outputs,
             toplevels,
             &self.wayland_helper,

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -161,18 +161,10 @@ impl ScreenCast {
         }
 
         // Show dialog to prompt for what to capture
-        let outputs = self
-            .wayland_helper
-            .outputs()
-            .iter()
-            .filter_map(|o| Some((o.clone(), self.wayland_helper.output_info(o)?)))
-            .collect();
-        let toplevels = self.wayland_helper.toplevels();
         let Some(capture_sources) = screencast_dialog::show_screencast_prompt(
             &self.tx,
             app_id,
-            outputs,
-            toplevels,
+            multiple,
             &self.wayland_helper,
         )
         .await

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -168,8 +168,13 @@ impl ScreenCast {
             .filter_map(|o| Some((o.clone(), self.wayland_helper.output_info(o)?)))
             .collect();
         let toplevels = self.wayland_helper.toplevels();
-        let Some(capture_sources) =
-            screencast_dialog::show_screencast_prompt(&self.tx, outputs, toplevels).await
+        let Some(capture_sources) = screencast_dialog::show_screencast_prompt(
+            &self.tx,
+            outputs,
+            toplevels,
+            &self.wayland_helper,
+        )
+        .await
         else {
             return PortalResponse::Cancelled;
         };

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -170,8 +170,12 @@ pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Command<cra
 }
 
 fn list_button(label: &str, is_selected: bool, msg: Msg) -> cosmic::Element<Msg> {
-    // TODO text style
-    let text = widget::text(label);
+    let text = widget::text(label).style(theme::style::Text::Custom(|theme| {
+        let container = theme.current_container();
+        cosmic::iced_core::widget::text::Appearance {
+            color: Some(container.on.into()),
+        }
+    }));
     let button = widget::button(text)
         .width(iced::Length::Fill)
         .padding(0)

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -1,0 +1,245 @@
+use crate::app::{CosmicPortal, OutputState};
+use crate::fl;
+use cosmic::iced::{self, window, Limits};
+use cosmic::iced_runtime::command::platform_specific::wayland::layer_surface::SctkLayerSurfaceSettings;
+use cosmic::iced_sctk::commands::layer_surface::{
+    destroy_layer_surface, get_layer_surface, KeyboardInteractivity, Layer,
+};
+use cosmic::{theme, widget};
+use cosmic_client_toolkit::sctk::output::OutputInfo;
+use cosmic_client_toolkit::toplevel_info::ToplevelInfo;
+use cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1;
+use once_cell::sync::Lazy;
+use tokio::sync::mpsc;
+use wayland_client::protocol::wl_output::WlOutput;
+
+// TODO translate
+
+pub static SCREENCAST_ID: Lazy<window::Id> = Lazy::new(window::Id::unique);
+
+pub async fn show_screencast_prompt(
+    subscription_tx: &mpsc::Sender<crate::subscription::Event>,
+    outputs: Vec<(WlOutput, OutputInfo)>,
+    toplevels: Vec<(ZcosmicToplevelHandleV1, ToplevelInfo)>,
+    // TODO toplevels
+) -> Option<CaptureSources> {
+    dbg!(&outputs);
+    dbg!(&toplevels);
+    let (tx, mut rx) = mpsc::channel(1);
+    let args = Args {
+        outputs,
+        toplevels,
+        tx,
+        capture_sources: Default::default(),
+        tab: Tab::Outputs, // TODO
+    };
+    subscription_tx
+        .send(crate::subscription::Event::Screencast(args))
+        .await
+        .unwrap();
+    rx.recv().await.unwrap()
+}
+
+fn create_dialog() -> cosmic::Command<crate::app::Msg> {
+    get_layer_surface(SctkLayerSurfaceSettings {
+        id: *SCREENCAST_ID,
+        keyboard_interactivity: KeyboardInteractivity::Exclusive,
+        namespace: "screencast".into(),
+        layer: Layer::Overlay,
+        size: None,
+        ..Default::default()
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Tab {
+    Outputs,
+    Windows,
+}
+
+#[derive(Clone)]
+pub struct Args {
+    // TODO multiple arg, etc?
+    outputs: Vec<(WlOutput, OutputInfo)>,
+    toplevels: Vec<(ZcosmicToplevelHandleV1, ToplevelInfo)>,
+    // Should be oneshot, but need `Clone` bound
+    tx: mpsc::Sender<Option<CaptureSources>>,
+    capture_sources: CaptureSources,
+    tab: Tab,
+}
+
+// TODO order?
+#[derive(Clone, Debug, Default)]
+pub struct CaptureSources {
+    pub outputs: Vec<WlOutput>,
+    pub toplevels: Vec<ZcosmicToplevelHandleV1>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Msg {
+    ActivateTab(widget::segmented_button::Entity),
+    SelectOutput(WlOutput),
+    SelectToplevel(ZcosmicToplevelHandleV1),
+    Share,
+    Cancel,
+}
+
+fn active_tab(portal: &CosmicPortal) -> Tab {
+    *portal.screencast_tab_model.active_data::<Tab>().unwrap()
+}
+
+pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Command<crate::app::Msg> {
+    let Some(args) = portal.screencast_args.as_mut() else {
+        return cosmic::Command::none();
+    };
+
+    match msg {
+        Msg::ActivateTab(tab) => {
+            portal.screencast_tab_model.activate(tab);
+        }
+        Msg::SelectOutput(output) => {
+            if let Some(idx) = args
+                .capture_sources
+                .outputs
+                .iter()
+                .position(|x| x == &output)
+            {
+                args.capture_sources.outputs.remove(idx);
+            } else {
+                args.capture_sources.outputs.push(output);
+            }
+        }
+        Msg::SelectToplevel(toplevel) => {
+            if let Some(idx) = args
+                .capture_sources
+                .toplevels
+                .iter()
+                .position(|x| x == &toplevel)
+            {
+                args.capture_sources.toplevels.remove(idx);
+            } else {
+                args.capture_sources.toplevels.push(toplevel);
+            }
+        }
+        Msg::Share => {
+            if let Some(args) = portal.screencast_args.take() {
+                let tx = args.tx;
+                let response = args.capture_sources;
+                tokio::spawn(async move {
+                    if let Err(err) = tx.send(Some(response)).await {
+                        log::error!("Failed to send screencast event");
+                    }
+                });
+                return destroy_layer_surface(*SCREENCAST_ID);
+            }
+        }
+        Msg::Cancel => {
+            if let Some(args) = portal.screencast_args.take() {
+                let tx = args.tx;
+                tokio::spawn(async move {
+                    if let Err(err) = tx.send(None).await {
+                        log::error!("Failed to send screencast event");
+                    }
+                });
+                return destroy_layer_surface(*SCREENCAST_ID);
+            }
+        }
+    }
+    cosmic::Command::none()
+}
+
+pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Command<crate::app::Msg> {
+    let mut command = cosmic::Command::none();
+    if portal.screencast_args.is_none() {
+        portal.screencast_tab_model.clear();
+        portal
+            .screencast_tab_model
+            .insert()
+            .data(Tab::Outputs)
+            .text("Output");
+        portal
+            .screencast_tab_model
+            .insert()
+            .data(Tab::Windows)
+            .text("Window");
+        portal.screencast_tab_model.activate_position(0); // XXX
+        command = create_dialog();
+    } // TODO: else, update dialog? or error.
+    portal.screencast_args = Some(args);
+    command
+}
+
+fn list_button(label: &str, is_selected: bool, msg: Msg) -> cosmic::Element<Msg> {
+    // TODO text style
+    let text = widget::text(label);
+    let button = widget::button(text)
+        .width(iced::Length::Fill)
+        .padding(0)
+        // TODO hover style? Etc.
+        // .style(theme::style::Button::Text)
+        .style(theme::style::Button::Transparent)
+        .selected(is_selected)
+        .on_press(msg);
+    let mut children = vec![button.into()];
+    // TODO
+    if is_selected {
+        children.push(widget::text("✓").into());
+    }
+    widget::row::with_children(children).into()
+}
+
+pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
+    let Some(args) = portal.screencast_args.as_ref() else {
+        return widget::horizontal_space(iced::Length::Fixed(1.0)).into();
+    };
+    let mut cancel_button = widget::button::standard(fl!("cancel")).on_press(Msg::Cancel);
+    let mut share_button =
+        widget::button::standard(fl!("share")).style(cosmic::style::Button::Suggested);
+    if !args.capture_sources.outputs.is_empty() || !args.capture_sources.toplevels.is_empty() {
+        share_button = share_button.on_press(Msg::Share);
+    }
+
+    let tabs =
+        widget::tab_bar::horizontal(&portal.screencast_tab_model).on_activate(Msg::ActivateTab);
+
+    let mut list = widget::ListColumn::new();
+    match active_tab(portal) {
+        Tab::Outputs => {
+            for (output, output_info) in &args.outputs {
+                let label = output_info.name.as_ref().unwrap();
+                let is_selected = args.capture_sources.outputs.contains(output);
+                list = list.add(list_button(
+                    label,
+                    is_selected,
+                    Msg::SelectOutput(output.clone()),
+                ));
+            }
+        }
+        Tab::Windows => {
+            for (toplevel, toplevel_info) in &args.toplevels {
+                let label = &toplevel_info.title;
+                let is_selected = args.capture_sources.toplevels.contains(toplevel);
+                list = list.add(list_button(
+                    label,
+                    is_selected,
+                    Msg::SelectToplevel(toplevel.clone()),
+                ));
+            }
+        }
+    }
+
+    // XXX
+    let app_name = "APP NAME";
+
+    // TODO adjust text for multiple select, types?
+    let description = format!("The system wants to share the contents of your screen with \"{}\". Select a screen or window to share.", app_name);
+
+    let control = widget::column::with_children(vec![tabs.into(), list.into()]);
+
+    widget::dialog("Share your screen")
+        .body(description)
+        .secondary_action(cancel_button)
+        .primary_action(share_button)
+        .control(control)
+        .into()
+}

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -25,8 +25,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use wayland_client::protocol::wl_output::WlOutput;
 
-// TODO translate
-
 pub static SCREENCAST_ID: Lazy<window::Id> = Lazy::new(window::Id::unique);
 
 pub async fn show_screencast_prompt(
@@ -243,14 +241,14 @@ pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Command<cra
                 .screencast_tab_model
                 .insert()
                 .data(Tab::Outputs)
-                .text("Output");
+                .text(fl!("output"));
         }
         if args.source_types.contains(SourceType::Window) {
             portal
                 .screencast_tab_model
                 .insert()
                 .data(Tab::Windows)
-                .text("Window");
+                .text(fl!("window"));
         }
         portal.screencast_tab_model.activate_position(0);
         command = create_dialog();
@@ -367,16 +365,15 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
         }
     };
 
-    let app_name = args.app_name.as_deref().unwrap_or("Unkown Application"); // TODO translate
-
-    // TODO adjust text for multiple select, types?
-    let description = format!("The system wants to share the contents of your screen with \"{}\". Select a screen or window to share.", app_name);
+    let unknown = fl!("unknown-application");
+    let app_name = args.app_name.as_deref().unwrap_or(&unknown);
 
     let control = widget::column::with_children(vec![tabs.into(), list.into()]);
 
     KeyboardWrapper::new(
         widget::dialog("Share your screen")
-            .body(description)
+            // TODO adjust text for multiple select, types?
+            .body(fl!("share-screen", "description", app_name = app_name))
             .secondary_action(cancel_button)
             .primary_action(share_button)
             .control(control),

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -392,7 +392,10 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
                     Msg::SelectToplevel(toplevel.clone()),
                 ));
             }
-            list.into()
+            cosmic::widget::scrollable(list)
+                .height(iced::Length::Fill)
+                .width(iced::Length::Fill)
+                .into()
         }
     };
 

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -304,21 +304,23 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
     let tabs =
         widget::tab_bar::horizontal(&portal.screencast_tab_model).on_activate(Msg::ActivateTab);
 
-    let mut list = widget::ListColumn::new();
-    match active_tab(portal) {
+    let list: cosmic::Element<_> = match active_tab(portal) {
         Tab::Outputs => {
+            let mut children = Vec::new();
             for (output, output_info, image_handle) in &args.outputs {
                 let label = output_info.name.as_ref().unwrap();
                 let is_selected = args.capture_sources.outputs.contains(output);
-                list = list.add(output_button(
+                children.push(output_button(
                     label,
                     is_selected,
                     image_handle.as_ref(),
                     Msg::SelectOutput(output.clone()),
                 ));
             }
+            widget::row::with_children(children).spacing(8).into()
         }
         Tab::Windows => {
+            let mut list = widget::ListColumn::new();
             for (toplevel, toplevel_info, icon) in &args.toplevels {
                 let icon = IconSource::from_unknown(icon.as_deref().unwrap_or_default());
                 let label = &toplevel_info.title;
@@ -330,8 +332,9 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
                     Msg::SelectToplevel(toplevel.clone()),
                 ));
             }
+            list.into()
         }
-    }
+    };
 
     let app_name = args.app_name.as_deref().unwrap_or("Unkown Application"); // TODO translate
 

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -160,7 +160,7 @@ impl Screenshot {
         let mut map = HashMap::with_capacity(outputs.len());
         for (output, _, name) in outputs {
             let frame = wayland_helper
-                .capture_source_shm(CaptureSource::Output(&output), false)
+                .capture_source_shm(CaptureSource::Output(output), false)
                 .await
                 .ok_or_else(|| anyhow::anyhow!("shm screencopy failed"))?;
             map.insert(name, Arc::new(frame.image()?));
@@ -224,7 +224,7 @@ impl Screenshot {
             let mut frames = Vec::with_capacity(outputs.len());
             for (output, (output_x, output_y), _) in outputs {
                 let frame = wayland_helper
-                    .capture_source_shm(CaptureSource::Output(&output), false)
+                    .capture_source_shm(CaptureSource::Output(output), false)
                     .await
                     .ok_or_else(|| anyhow::anyhow!("shm screencopy failed"))?;
                 let rect = Rect {

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -2,6 +2,7 @@
 
 use cosmic::cosmic_config::CosmicConfigEntry;
 use cosmic::iced::clipboard::mime::AsMimeTypes;
+use cosmic::iced::keyboard::{key::Named, Key};
 use cosmic::iced::wayland::actions::data_device::ActionInner;
 use cosmic::iced::wayland::actions::layer_surface::{IcedOutput, SctkLayerSurfaceSettings};
 use cosmic::iced::{window, Limits};
@@ -24,7 +25,7 @@ use zbus::zvariant;
 use crate::app::{CosmicPortal, OutputState};
 use crate::config::{self, screenshot::ImageSaveLocation};
 use crate::wayland::{CaptureSource, WaylandHelper};
-use crate::widget::rectangle_selection::DragState;
+use crate::widget::{keyboard_wrapper::KeyboardWrapper, rectangle_selection::DragState};
 use crate::{fl, subscription, PortalResponse};
 
 // TODO save to /run/user/$UID/doc/ with document portal fuse filesystem?
@@ -513,22 +514,29 @@ pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<Msg
         return horizontal_space(Length::Fixed(1.0)).into();
     };
     let theme = portal.core.system_theme().cosmic();
-    crate::widget::screenshot::ScreenshotSelection::new(
-        args.choice.clone(),
-        raw_image.clone(),
-        Msg::Capture,
-        Msg::Cancel,
-        output,
-        id,
-        Msg::OutputChanged,
-        Msg::Choice,
-        Msg::DragCommand,
-        &args.toplevel_images,
-        Msg::WindowChosen,
-        &portal.location_options,
-        args.location as usize,
-        Msg::Location,
-        theme.spacing,
+    KeyboardWrapper::new(
+        crate::widget::screenshot::ScreenshotSelection::new(
+            args.choice.clone(),
+            raw_image.clone(),
+            Msg::Capture,
+            Msg::Cancel,
+            output,
+            id,
+            Msg::OutputChanged,
+            Msg::Choice,
+            Msg::DragCommand,
+            &args.toplevel_images,
+            Msg::WindowChosen,
+            &portal.location_options,
+            args.location as usize,
+            Msg::Location,
+            theme.spacing,
+        ),
+        |key| match key {
+            Key::Named(Named::Enter) => Some(Msg::Capture),
+            Key::Named(Named::Escape) => Some(Msg::Cancel),
+            _ => None,
+        },
     )
     .into()
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -21,6 +21,7 @@ pub enum Event {
     Access(crate::access::AccessDialogArgs),
     FileChooser(crate::file_chooser::Args),
     Screenshot(crate::screenshot::Args),
+    Screencast(crate::screencast_dialog::Args),
     Accent(Srgba),
     IsDark(bool),
     HighContrast(bool),
@@ -72,6 +73,7 @@ impl Debug for Event {
                 .field("location", location)
                 .field("toplevel_images", toplevel_images)
                 .finish(),
+            Event::Screencast(_) => todo!(),
             Event::Accent(a) => a.fmt(f),
             Event::IsDark(t) => t.fmt(f),
             Event::HighContrast(c) => c.fmt(f),
@@ -137,7 +139,10 @@ pub(crate) async fn process_changes(
                     DBUS_PATH,
                     Screenshot::new(wayland_helper.clone(), tx.clone()),
                 )?
-                .serve_at(DBUS_PATH, ScreenCast::new(wayland_helper.clone()))?
+                .serve_at(
+                    DBUS_PATH,
+                    ScreenCast::new(wayland_helper.clone(), tx.clone()),
+                )?
                 .serve_at(DBUS_PATH, Settings::new())?
                 .build()
                 .await?;
@@ -160,6 +165,11 @@ pub(crate) async fn process_changes(
                     Event::Screenshot(args) => {
                         if let Err(err) = output.send(Event::Screenshot(args)).await {
                             log::error!("Error sending screenshot event: {:?}", err);
+                        };
+                    }
+                    Event::Screencast(args) => {
+                        if let Err(err) = output.send(Event::Screencast(args)).await {
+                            log::error!("Error sending screencast event: {:?}", err);
                         };
                     }
                     Event::Accent(a) => {

--- a/src/widget/keyboard_wrapper.rs
+++ b/src/widget/keyboard_wrapper.rs
@@ -1,0 +1,192 @@
+use cosmic::{
+    iced::Limits,
+    iced_core::{
+        event::{self, Event},
+        keyboard, layout, mouse, overlay, renderer, touch,
+        widget::{tree, Operation, Tree},
+        Clipboard, Element, Layout, Length, Rectangle, Shell, Size, Widget,
+    },
+    iced_renderer::core::widget::OperationOutputWrapper,
+    iced_style,
+};
+
+#[allow(missing_debug_implementations)]
+pub struct KeyboardWrapper<'a, Message> {
+    content: Element<'a, Message, cosmic::Theme, cosmic::Renderer>,
+    handler: fn(keyboard::Key) -> Option<Message>,
+}
+
+impl<'a, Message> KeyboardWrapper<'a, Message> {
+    /// Creates a [`KeyboardWrapper`] with the given content.
+    pub fn new(
+        content: impl Into<Element<'a, Message, cosmic::Theme, cosmic::Renderer>>,
+        handler: fn(keyboard::Key) -> Option<Message>,
+    ) -> Self {
+        KeyboardWrapper {
+            content: content.into(),
+            handler,
+        }
+    }
+}
+
+impl<'a, Message> Widget<Message, cosmic::Theme, cosmic::Renderer> for KeyboardWrapper<'a, Message>
+where
+    Message: Clone,
+{
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content));
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &cosmic::Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &cosmic::Renderer,
+        operation: &mut dyn Operation<OperationOutputWrapper<Message>>,
+    ) {
+        self.content
+            .as_widget()
+            .operate(&mut tree.children[0], layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &cosmic::Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        if let event::Status::Captured = self.content.as_widget_mut().on_event(
+            &mut tree.children[0],
+            event.clone(),
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        ) {
+            return event::Status::Captured;
+        }
+
+        match event {
+            Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
+                if let Some(message) = (self.handler)(key) {
+                    shell.publish(message.clone());
+                    event::Status::Captured
+                } else {
+                    event::Status::Ignored
+                }
+            }
+            /*
+                keyboard::key::Named::Escape => {
+                    event::Status::Ignored
+                }
+                keyboard::key::Named::Enter => {
+                    event::Status::Ignored
+                }
+                _ => event::Status::Ignored
+            },
+            */
+            _ => event::Status::Ignored,
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &cosmic::Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut cosmic::Renderer,
+        theme: &cosmic::Theme,
+        renderer_style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            renderer_style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &cosmic::Renderer,
+    ) -> Option<overlay::Element<'b, Message, cosmic::Theme, cosmic::Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(&mut tree.children[0], layout, renderer)
+    }
+
+    fn drag_destinations(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        renderer: &cosmic::Renderer,
+        dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
+    ) {
+        if let Some(state) = state.children.iter().next() {
+            self.content
+                .as_widget()
+                .drag_destinations(state, layout, renderer, dnd_rectangles);
+        }
+    }
+}
+
+impl<'a, Message> From<KeyboardWrapper<'a, Message>>
+    for Element<'a, Message, cosmic::Theme, cosmic::Renderer>
+where
+    Message: 'a + Clone,
+{
+    fn from(
+        area: KeyboardWrapper<'a, Message>,
+    ) -> Element<'a, Message, cosmic::Theme, cosmic::Renderer> {
+        Element::new(area)
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1,3 +1,4 @@
+pub mod keyboard_wrapper;
 pub mod output_selection;
 pub mod rectangle_selection;
 pub mod screenshot;

--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -60,7 +60,7 @@ pub struct ScreenshotSelection<'a, Msg> {
 
 // for now lets just support selecting the output
 
-pub struct MyImage(Arc<RgbaImage>);
+pub struct MyImage(pub Arc<RgbaImage>);
 
 impl AsRef<[u8]> for MyImage {
     fn as_ref(&self) -> &[u8] {


### PR DESCRIPTION
https://github.com/pop-os/xdg-desktop-portal-cosmic/issues/48.

The screencast dialog here should work. But still needs various styling changes and various other things:
- Show preview of outputs. Icons of toplevels.
- Consider what type of source the client of the portal requested capture of, and if it allows multiple sources
  * With multiple, how should we order them?

Capturing all monitors as a single source probably will need compositor support.

A screenshot dialog should be fairly easy, but isn't added yet.