### PR TITLE
Background portal (Rebased 05-21-2025)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8631,6 +8631,7 @@ dependencies = [
  "rust-embed",
  "rustix 0.38.44",
  "serde",
+ "shlex",
  "tempfile",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ env_logger = "0.11.6"
 dirs = "6.0.0"
 chrono = "0.4"
 url = "2.5"
+shlex = "1"
 # i18n
 i18n-embed = { version = "0.15.3", features = [
     "fluent-system",

--- a/cosmic-portal-config/src/background.rs
+++ b/cosmic-portal-config/src/background.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Background {
+    /// Default preference for NotifyBackground's dialog
+    pub default_perm: PermissionDialog,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub enum PermissionDialog {
+    /// Grant apps permission to run in the background
+    Allow,
+    /// Deny apps permission to run in the background
+    Deny,
+    /// Always ask if new apps should be granted background permissions
+    #[default]
+    Ask,
+}

--- a/cosmic-portal-config/src/lib.rs
+++ b/cosmic-portal-config/src/lib.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+pub mod background;
 pub mod screenshot;
 
 use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
 use serde::{Deserialize, Serialize};
 
+use background::Background;
 use screenshot::Screenshot;
 
 pub const APP_ID: &str = "com.system76.CosmicPortal";
@@ -17,6 +19,8 @@ pub const CONFIG_VERSION: u64 = 1;
 pub struct Config {
     /// Interactive screenshot settings
     pub screenshot: Screenshot,
+    /// Background portal settings
+    pub background: Background,
 }
 
 impl Config {

--- a/data/cosmic.portal
+++ b/data/cosmic.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.cosmic
-Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.ScreenCast
+Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.ScreenCast
 UseIn=COSMIC

--- a/examples/background.rs
+++ b/examples/background.rs
@@ -2,10 +2,10 @@
 
 use ashpd::desktop::background::Background;
 use cosmic::{
-    app::{self, message, Core},
+    app::{self, Core},
     executor,
     iced::{Length, Size},
-    widget, Command,
+    widget, Task,
 };
 
 #[derive(Clone, Debug)]
@@ -50,14 +50,14 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    fn init(core: Core, _: Self::Flags) -> (Self, app::Command<Self::Message>) {
+    fn init(core: Core, _: Self::Flags) -> (Self, app::Task<Self::Message>) {
         (
             Self {
                 core,
                 executable: std::env::args().next().unwrap(),
                 background_allowed: false,
             },
-            Command::none(),
+            Task::none(),
         )
     }
 
@@ -81,16 +81,16 @@ impl cosmic::Application for App {
         .into()
     }
 
-    fn update(&mut self, message: Self::Message) -> app::Command<Self::Message> {
+    fn update(&mut self, message: Self::Message) -> app::Task<Self::Message> {
         match message {
             Message::BackgroundResponse(background_allowed) => {
                 log::info!("Permission to run in the background: {background_allowed}");
                 self.background_allowed = background_allowed;
-                Command::none()
+                Task::none()
             }
             Message::RequestBackground => {
                 let executable = self.executable.clone();
-                Command::perform(Self::request_background(executable), |result| {
+                Task::perform(Self::request_background(executable), |result| {
                     let background_allowed = match result {
                         Ok(response) => {
                             assert!(
@@ -105,7 +105,7 @@ impl cosmic::Application for App {
                         }
                     };
 
-                    message::app(Message::BackgroundResponse(background_allowed))
+                    cosmic::Action::App(Message::BackgroundResponse(background_allowed))
                 })
             }
         }

--- a/examples/background.rs
+++ b/examples/background.rs
@@ -70,7 +70,7 @@ impl cosmic::Application for App {
             })
             .width(Length::Fill)
             .into(),
-            widget::button("Run in background")
+            widget::button::standard("Run in background")
                 .on_press(Message::RequestBackground)
                 .padding(8.0)
                 .into(),

--- a/examples/background.rs
+++ b/examples/background.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use ashpd::desktop::background::Background;
+use cosmic::{
+    app::{self, message, Core},
+    executor,
+    iced::{Length, Size},
+    widget, Command,
+};
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    BackgroundResponse(bool),
+    RequestBackground,
+}
+
+pub struct App {
+    core: Core,
+    executable: String,
+    background_allowed: bool,
+}
+
+impl App {
+    async fn request_background(executable: String) -> ashpd::Result<Background> {
+        log::info!("Requesting permission to run in the background for: {executable}");
+        // Based off of the ashpd docs
+        // https://docs.rs/ashpd/latest/ashpd/desktop/background/index.html
+        Background::request()
+            .reason("Testing the background portal")
+            .auto_start(false)
+            .dbus_activatable(false)
+            .command(&[executable])
+            .send()
+            .await?
+            .response()
+    }
+}
+
+impl cosmic::Application for App {
+    type Executor = executor::single::Executor;
+    type Flags = ();
+    type Message = Message;
+    const APP_ID: &'static str = "org.cosmic.BackgroundPortalExample";
+
+    fn core(&self) -> &Core {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut Core {
+        &mut self.core
+    }
+
+    fn init(core: Core, _: Self::Flags) -> (Self, app::Command<Self::Message>) {
+        (
+            Self {
+                core,
+                executable: std::env::args().next().unwrap(),
+                background_allowed: false,
+            },
+            Command::none(),
+        )
+    }
+
+    fn view(&self) -> cosmic::Element<Self::Message> {
+        widget::row::with_children(vec![
+            widget::text::title3(if self.background_allowed {
+                "Running in background"
+            } else {
+                "Not running in background"
+            })
+            .width(Length::Fill)
+            .into(),
+            widget::button("Run in background")
+                .on_press(Message::RequestBackground)
+                .padding(8.0)
+                .into(),
+        ])
+        .width(Length::Fill)
+        .height(Length::Fixed(64.0))
+        .padding(16.0)
+        .into()
+    }
+
+    fn update(&mut self, message: Self::Message) -> app::Command<Self::Message> {
+        match message {
+            Message::BackgroundResponse(background_allowed) => {
+                log::info!("Permission to run in the background: {background_allowed}");
+                self.background_allowed = background_allowed;
+                Command::none()
+            }
+            Message::RequestBackground => {
+                let executable = self.executable.clone();
+                Command::perform(Self::request_background(executable), |result| {
+                    let background_allowed = match result {
+                        Ok(response) => {
+                            assert!(
+                                !response.auto_start(),
+                                "Auto start shouldn't have been enabled"
+                            );
+                            response.run_in_background()
+                        }
+                        Err(e) => {
+                            log::error!("Background portal request failed: {e:?}");
+                            false
+                        }
+                    };
+
+                    message::app(Message::BackgroundResponse(background_allowed))
+                })
+            }
+        }
+    }
+}
+
+// TODO: Write a small flatpak manifest in order to test this better
+#[tokio::main]
+async fn main() -> cosmic::iced::Result {
+    env_logger::Builder::from_default_env().init();
+    let settings = app::Settings::default()
+        .resizable(None)
+        .size(Size::new(512.0, 128.0))
+        .exit_on_close(false);
+    app::run::<App>(settings, ())
+}

--- a/i18n/en/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/en/xdg_desktop_portal_cosmic.ftl
@@ -13,3 +13,9 @@ share-screen = Share your screen
 unknown-application = Unknown Application
 output = Output
 window = Window
+
+# Background portal
+allow-once = Allow once
+deny = Deny
+bg-dialog-title = Background
+bg-dialog-body = {$appname} requests to run in the background. This will allow it to run without any open windows.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
-use crate::{access, config, file_chooser, screencast_dialog, screenshot, subscription};
+use crate::{
+    access, background, config, file_chooser, fl, screencast_dialog, screenshot, subscription,
+};
 use cosmic::iced_core::event::wayland::OutputEvent;
 use cosmic::widget;
 use cosmic::Task;
@@ -14,12 +16,7 @@ pub(crate) fn run() -> cosmic::iced::Result {
     let settings = cosmic::app::Settings::default()
         .no_main_window(true)
         .exit_on_close(false);
-    let (config, config_handler) = config::Config::load();
-    let flags = Flags {
-        config,
-        config_handler,
-    };
-    cosmic::app::run::<CosmicPortal>(settings, flags)
+    cosmic::app::run::<CosmicPortal>(settings, ())
 }
 
 // run iced app with no main surface
@@ -28,7 +25,7 @@ pub struct CosmicPortal {
     pub tx: Option<tokio::sync::mpsc::Sender<subscription::Event>>,
 
     pub config_handler: Option<cosmic_config::Config>,
-    pub config: config::Config,
+    pub tx_conf: Option<tokio::sync::watch::Sender<config::Config>>,
 
     pub access_args: Option<access::AccessDialogArgs>,
 
@@ -41,6 +38,8 @@ pub struct CosmicPortal {
     pub location_options: Vec<String>,
     pub prev_rectangle: Option<screenshot::Rect>,
     pub wayland_helper: crate::wayland::WaylandHelper,
+
+    pub background_prompts: HashMap<window::Id, background::Args>,
 
     pub outputs: Vec<OutputState>,
     pub active_output: Option<WlOutput>,
@@ -63,6 +62,7 @@ pub enum Msg {
     FileChooser(window::Id, file_chooser::Msg),
     Screenshot(screenshot::Msg),
     Screencast(screencast_dialog::Msg),
+    Background(background::Msg),
     Portal(subscription::Event),
     Output(OutputEvent, WlOutput),
     ConfigSetScreenshot(config::screenshot::Screenshot),
@@ -70,16 +70,10 @@ pub enum Msg {
     ConfigSubUpdate(config::Config),
 }
 
-#[derive(Clone, Debug)]
-pub struct Flags {
-    pub config_handler: Option<cosmic_config::Config>,
-    pub config: config::Config,
-}
-
 impl cosmic::Application for CosmicPortal {
     type Executor = cosmic::executor::Default;
 
-    type Flags = Flags;
+    type Flags = ();
 
     type Message = Msg;
 
@@ -95,18 +89,15 @@ impl cosmic::Application for CosmicPortal {
 
     fn init(
         core: app::Core,
-        Flags {
-            config_handler,
-            config,
-        }: Self::Flags,
+        _: Self::Flags,
     ) -> (Self, cosmic::iced::Task<cosmic::Action<Self::Message>>) {
         let wayland_conn = crate::wayland::connect_to_wayland();
         let wayland_helper = crate::wayland::WaylandHelper::new(wayland_conn);
         (
             Self {
                 core,
-                config_handler,
-                config,
+                config_handler: None,
+                tx_conf: None,
                 access_args: Default::default(),
                 file_choosers: Default::default(),
                 screenshot_args: Default::default(),
@@ -114,6 +105,7 @@ impl cosmic::Application for CosmicPortal {
                 screencast_tab_model: Default::default(),
                 location_options: Vec::new(),
                 prev_rectangle: Default::default(),
+                background_prompts: Default::default(),
                 outputs: Default::default(),
                 active_output: Default::default(),
                 wayland_helper,
@@ -134,6 +126,8 @@ impl cosmic::Application for CosmicPortal {
             screencast_dialog::view(self).map(Msg::Screencast)
         } else if self.outputs.iter().any(|o| o.id == id) {
             screenshot::view(self, id).map(Msg::Screenshot)
+        } else if self.background_prompts.contains_key(&id) {
+            background::view(self, id).map(Msg::Background)
         } else {
             file_chooser::view(self, id)
         }
@@ -160,17 +154,29 @@ impl cosmic::Application for CosmicPortal {
                 subscription::Event::CancelScreencast(handle) => {
                     screencast_dialog::cancel(self, handle).map(cosmic::Action::App)
                 }
+                subscription::Event::Background(args) => {
+                    background::update_args(self, args).map(cosmic::app::Message::App)
+                }
                 subscription::Event::Config(config) => self.update(Msg::ConfigSubUpdate(config)),
                 subscription::Event::Accent(_)
                 | subscription::Event::IsDark(_)
-                | subscription::Event::HighContrast(_) => cosmic::iced::Task::none(),
-                subscription::Event::Init(tx) => {
+                | subscription::Event::HighContrast(_)
+                | subscription::Event::BackgroundToplevels => cosmic::iced::Task::none(),
+                subscription::Event::Init {
+                    tx,
+                    tx_conf,
+                    handler,
+                } => {
+                    let config = tx_conf.borrow().clone();
                     self.tx = Some(tx);
-                    Task::none()
+                    self.tx_conf = Some(tx_conf);
+                    self.config_handler = handler;
+                    self.update(Msg::ConfigSubUpdate(config))
                 }
             },
             Msg::Screenshot(m) => screenshot::update_msg(self, m).map(cosmic::Action::App),
             Msg::Screencast(m) => screencast_dialog::update_msg(self, m).map(cosmic::Action::App),
+            Msg::Background(m) => background::update_msg(self, m).map(cosmic::Action::App),
             Msg::Output(o_event, wl_output) => {
                 match o_event {
                     OutputEvent::Created(Some(info))
@@ -244,19 +250,36 @@ impl cosmic::Application for CosmicPortal {
                 cosmic::iced::Task::none()
             }
             Msg::ConfigSetScreenshot(screenshot) => {
-                match &mut self.config_handler {
-                    Some(handler) => {
-                        if let Err(e) = self.config.set_screenshot(handler, screenshot) {
-                            log::error!("Failed to save screenshot config: {e}")
-                        }
+                match (self.tx_conf.as_mut(), &mut self.config_handler) {
+                    (Some(tx), Some(handler)) => {
+                        tx.send_if_modified(|config| {
+                            if screenshot != config.screenshot {
+                                if let Err(e) = config.set_screenshot(handler, screenshot) {
+                                    log::error!("Failed to save screenshot config: {e}");
+                                }
+                                true
+                            } else {
+                                false
+                            }
+                        });
                     }
-                    None => log::error!("Failed to save config: No config handler"),
+                    _ => log::error!("Failed to save config: No config handler"),
                 }
 
                 cosmic::iced::Task::none()
             }
             Msg::ConfigSubUpdate(config) => {
-                self.config = config;
+                if let Some(tx) = self.tx_conf.as_ref() {
+                    tx.send_if_modified(|current| {
+                        if config != *current {
+                            *current = config;
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                }
+
                 cosmic::iced::Task::none()
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,7 +155,7 @@ impl cosmic::Application for CosmicPortal {
                     screencast_dialog::cancel(self, handle).map(cosmic::Action::App)
                 }
                 subscription::Event::Background(args) => {
-                    background::update_args(self, args).map(cosmic::app::Message::App)
+                    background::update_args(self, args).map(cosmic::Action::App)
                 }
                 subscription::Event::Config(config) => self.update(Msg::ConfigSubUpdate(config)),
                 subscription::Event::Accent(_)

--- a/src/background.rs
+++ b/src/background.rs
@@ -326,8 +326,9 @@ async fn get_app_state_impl(
 }
 
 /// Status of running apps for [`Background::get_app_state`]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, zvariant::Type)]
-#[zvariant(signature = "u")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, zvariant::Type)]
+#[zvariant(signature = "v")]
+#[repr(u32)]
 enum AppStatus {
     /// No open windows
     Background = 0,
@@ -335,6 +336,15 @@ enum AppStatus {
     Running,
     /// In the foreground
     Active,
+}
+
+impl serde::Serialize for AppStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        zvariant::Value::U32(*self as u32).serialize(serializer)
+    }
 }
 
 /// Result vardict for [`Background::notify_background`]

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::sync::{Arc, Condvar, Mutex};
+
+// use ashpd::enumflags2::{bitflags, BitFlag, BitFlags};
+use cosmic::{iced::window, widget};
+use cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1;
+use futures::{FutureExt, TryFutureExt};
+use tokio::sync::{mpsc, watch};
+use zbus::{fdo, object_server::SignalContext, zvariant};
+
+use crate::{
+    app::CosmicPortal,
+    config::{self, background::PermissionDialog},
+    fl, subscription,
+    wayland::WaylandHelper,
+    PortalResponse,
+};
+
+/// Background portal backend
+///
+/// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.Background.html
+pub struct Background {
+    wayland_helper: WaylandHelper,
+    tx: mpsc::Sender<subscription::Event>,
+    rx_conf: watch::Receiver<config::Config>,
+}
+
+impl Background {
+    pub fn new(
+        wayland_helper: WaylandHelper,
+        tx: mpsc::Sender<subscription::Event>,
+        rx_conf: watch::Receiver<config::Config>,
+    ) -> Self {
+        let toplevel_signal = wayland_helper.toplevel_signal();
+        let toplevel_tx = tx.clone();
+        std::thread::Builder::new()
+            .name("background-toplevel-updates".into())
+            .spawn(move || Background::toplevel_signal(toplevel_signal, toplevel_tx))
+            .expect("Spawning toplevels update thread should succeed");
+
+        Self {
+            wayland_helper,
+            tx,
+            rx_conf,
+        }
+    }
+
+    /// Trigger [`Background::running_applications_changed`] on toplevel updates
+    fn toplevel_signal(signal: Arc<(Mutex<bool>, Condvar)>, tx: mpsc::Sender<subscription::Event>) {
+        loop {
+            let (lock, cvar) = &*signal;
+            let mut updated = lock.lock().unwrap();
+
+            log::debug!("Waiting for toplevel updates");
+            while !*updated {
+                updated = cvar.wait(updated).unwrap();
+            }
+
+            log::debug!("Emitting RunningApplicationsChanged in response to toplevel updates");
+            debug_assert!(*updated);
+            *updated = false;
+            if let Err(e) = tx.blocking_send(subscription::Event::BackgroundToplevels) {
+                log::warn!("Failed sending event to trigger RunningApplicationsChanged: {e:?}");
+            }
+        }
+    }
+}
+
+#[zbus::interface(name = "org.freedesktop.impl.portal.Background")]
+impl Background {
+    /// Status on running apps (active, running, or background)
+    async fn get_app_state(&self) -> fdo::Result<Vec<AppState>> {
+        let toplevels: Vec<_> = self
+            .wayland_helper
+            .toplevels()
+            .into_iter()
+            .map(|(_, info)| {
+                let status = if info
+                    .state
+                    .contains(&zcosmic_toplevel_handle_v1::State::Activated)
+                {
+                    AppStatus::Active
+                } else if !info.state.is_empty() {
+                    AppStatus::Running
+                } else {
+                    // xxx Is this the correct way to determine if a program is running in the
+                    // background? If a toplevel exists but isn't running, activated, et cetera,
+                    // then it logically must be in the background (?)
+                    AppStatus::Background
+                };
+
+                AppState {
+                    app_id: info.app_id,
+                    status,
+                }
+            })
+            .collect();
+
+        log::debug!("GetAppState returning {} toplevels", toplevels.len());
+        #[cfg(debug_assertions)]
+        log::trace!("App status: {toplevels:#?}");
+
+        Ok(toplevels)
+    }
+
+    /// Notifies the user that an app is running in the background
+    async fn notify_background(
+        &self,
+        handle: zvariant::ObjectPath<'_>,
+        app_id: String,
+        name: String,
+    ) -> PortalResponse<NotifyBackgroundResult> {
+        log::debug!("Request handle: {handle:?}");
+
+        // Request a copy of the config from the main app instance
+        // This is also cleaner than storing the config because it's difficult to keep it
+        // updated without synch primitives and we also avoid &mut self
+        let config = self.rx_conf.borrow().background;
+
+        match config.default_perm {
+            // Skip dialog based on default response set in configs
+            PermissionDialog::Allow => {
+                log::debug!("AUTO ALLOW {name} based on default permission");
+                PortalResponse::Success(NotifyBackgroundResult {
+                    result: PermissionResponse::Allow,
+                })
+            }
+            PermissionDialog::Deny => {
+                log::debug!("AUTO DENY {name} based on default permission");
+                PortalResponse::Success(NotifyBackgroundResult {
+                    result: PermissionResponse::Deny,
+                })
+            }
+            // Dialog
+            PermissionDialog::Ask => {
+                log::debug!("Requesting user permission for {app_id} ({name})",);
+
+                let handle = handle.to_owned();
+                let id = window::Id::unique();
+                let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+                self.tx
+                    .send(subscription::Event::Background(Args {
+                        handle,
+                        id,
+                        app_id,
+                        tx,
+                    }))
+                    .inspect_err(|e| {
+                        log::error!("Failed to send message to register permissions dialog: {e:?}")
+                    })
+                    .map_ok(|_| PortalResponse::<NotifyBackgroundResult>::Other)
+                    .map_err(|_| ())
+                    .and_then(|_| rx.recv().map(|out| out.ok_or(())))
+                    .unwrap_or_else(|_| PortalResponse::Other)
+                    .await
+            }
+        }
+    }
+
+    /// Enable or disable autostart for an application
+    ///
+    /// Deprecated but seemingly still in use
+    pub async fn enable_autostart(
+        &self,
+        app_id: String,
+        enable: bool,
+        commandline: Vec<String>,
+        flags: u32,
+    ) -> fdo::Result<bool> {
+        log::warn!("Autostart not implemented");
+        Ok(enable)
+    }
+
+    /// Emitted when running applications change their state
+    #[zbus(signal)]
+    pub async fn running_applications_changed(context: &SignalContext<'_>) -> zbus::Result<()>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, zvariant::Type)]
+#[zvariant(signature = "u")]
+pub enum AppStatus {
+    /// No open windows
+    Background = 0,
+    /// At least one opened window
+    Running,
+    /// In the foreground
+    Active,
+}
+
+#[derive(Clone, Debug, serde::Serialize, zvariant::Type)]
+#[zvariant(signature = "{sv}")]
+struct AppState {
+    app_id: String,
+    status: AppStatus,
+}
+
+/// Result vardict for [`Background::notify_background`]
+#[derive(Clone, Debug, zvariant::SerializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct NotifyBackgroundResult {
+    result: PermissionResponse,
+}
+
+/// Response for apps requesting to run in the background for [`Background::notify_background`]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, zvariant::Type)]
+#[zvariant(signature = "u")]
+pub enum PermissionResponse {
+    /// Background permission denied
+    Deny = 0,
+    /// Background permission allowed whenever asked
+    Allow,
+    /// Background permission allowed for a single instance
+    AllowOnce,
+}
+
+/// Background permissions dialog state
+#[derive(Clone, Debug)]
+pub struct Args {
+    pub handle: zvariant::ObjectPath<'static>,
+    pub id: window::Id,
+    pub app_id: String,
+    tx: mpsc::Sender<PortalResponse<NotifyBackgroundResult>>,
+}
+
+/// Background permissions dialog response
+#[derive(Debug, Clone)]
+pub enum Msg {
+    Response {
+        id: window::Id,
+        choice: PermissionResponse,
+    },
+    Cancel(window::Id),
+}
+
+// #[bitflags]
+// #[repr(u32)]
+// #[derive(Clone, Copy, Debug, PartialEq)]
+// enum AutostartFlags {
+//     DBus = 0x01,
+// }
+
+/// Permissions dialog
+pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<Msg> {
+    let name = portal
+        .background_prompts
+        .get(&id)
+        .map(|args| args.app_id.as_str())
+        // xxx What do I do here?
+        .unwrap_or("Invalid window id");
+
+    // TODO: Add cancel
+    widget::dialog(fl!("bg-dialog-title"))
+        .body(fl!("bg-dialog-body", appname = name))
+        .icon(widget::icon::from_name("dialog-warning-symbolic").size(64))
+        .primary_action(
+            widget::button::suggested(fl!("allow")).on_press(Msg::Response {
+                id,
+                choice: PermissionResponse::Allow,
+            }),
+        )
+        .secondary_action(
+            widget::button::suggested(fl!("allow-once")).on_press(Msg::Response {
+                id,
+                choice: PermissionResponse::AllowOnce,
+            }),
+        )
+        .tertiary_action(
+            widget::button::destructive(fl!("deny")).on_press(Msg::Response {
+                id,
+                choice: PermissionResponse::Deny,
+            }),
+        )
+        .into()
+}
+
+/// Update Background dialog args for a specific window
+pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Command<crate::app::Msg> {
+    if let Some(old) = portal.background_prompts.insert(args.id, args) {
+        // xxx Can this even happen?
+        log::trace!(
+            "Replaced old dialog args for (window: {:?}) (app: {}) (handle: {})",
+            old.id,
+            old.app_id,
+            old.handle
+        )
+    }
+
+    cosmic::Command::none()
+}
+
+pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Command<crate::app::Msg> {
+    match msg {
+        Msg::Response { id, choice } => {
+            let Some(Args {
+                handle,
+                id,
+                app_id,
+                tx,
+            }) = portal.background_prompts.remove(&id)
+            else {
+                log::warn!("Window {id:?} doesn't exist for some reason");
+                return cosmic::Command::none();
+            };
+
+            log::trace!(
+                "User selected {choice:?} for (app: {app_id}) (handle: {handle}) on window {id:?}"
+            );
+            // Return result to portal handler and update the config
+            tokio::spawn(async move {
+                if let Err(e) = tx
+                    .send(PortalResponse::Success(NotifyBackgroundResult {
+                        result: choice,
+                    }))
+                    .await
+                {
+                    log::error!(
+                        "Failed to send response from user to the background handler: {e:?}"
+                    );
+                }
+            });
+        }
+        Msg::Cancel(id) => {
+            let Some(Args {
+                handle,
+                id,
+                app_id,
+                tx,
+            }) = portal.background_prompts.remove(&id)
+            else {
+                log::warn!("Window {id:?} doesn't exist for some reason");
+                return cosmic::Command::none();
+            };
+
+            log::trace!(
+                "User cancelled dialog for (window: {:?}) (app: {}) (handle: {})",
+                id,
+                app_id,
+                handle
+            );
+            tokio::spawn(async move {
+                if let Err(e) = tx.send(PortalResponse::Cancelled).await {
+                    log::error!("Failed to send cancellation response to background handler {e:?}");
+                }
+            });
+        }
+    }
+
+    cosmic::Command::none()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod screencast_dialog;
 mod screencast_thread;
 mod screenshot;
 mod subscription;
+mod systemd;
 mod wayland;
 mod widget;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ pub use cosmic_portal_config as config;
 
 mod access;
 mod app;
+mod background;
 mod buffer;
 mod documents;
 mod file_chooser;

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -19,6 +19,7 @@ use std::borrow::Cow;
 use std::num::NonZeroU32;
 use std::{collections::HashMap, io, path::PathBuf};
 use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
 
 use wayland_client::protocol::wl_output::WlOutput;
 use zbus::zvariant;
@@ -150,11 +151,20 @@ pub struct RectDimension {
 pub struct Screenshot {
     wayland_helper: WaylandHelper,
     tx: Sender<subscription::Event>,
+    rx_conf: watch::Receiver<config::Config>,
 }
 
 impl Screenshot {
-    pub fn new(wayland_helper: WaylandHelper, tx: Sender<subscription::Event>) -> Self {
-        Self { wayland_helper, tx }
+    pub fn new(
+        wayland_helper: WaylandHelper,
+        tx: Sender<subscription::Event>,
+        rx_conf: watch::Receiver<config::Config>,
+    ) -> Self {
+        Self {
+            wayland_helper,
+            tx,
+            rx_conf,
+        }
     }
 
     async fn interactive_toplevel_images(
@@ -398,12 +408,9 @@ impl Screenshot {
     ) -> PortalResponse<ScreenshotResult> {
         // connection.object_server().at(&handle, Request);
 
-        // The screenshot handler is created when the portal is launched, but requests are
-        // handled on demand. The handler does not store extra state such as a reference to the
-        // portal. Storing a copy of the config is unideal because it would remain out of date.
-        //
-        // The most straightforward solution is to load the screenshot config here
-        let config = config::Config::load().0.screenshot;
+        // borrow() is simpler here as we don't need &mut self and reading a possibly out of
+        // date config isn't a major issue
+        let config = self.rx_conf.borrow().screenshot.clone();
 
         // TODO create handle, show dialog
         let mut outputs = Vec::new();
@@ -734,7 +741,11 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
             cosmic::task::message(crate::app::Msg::ConfigSetScreenshot(
                 config::screenshot::Screenshot {
                     choice,
-                    ..portal.config.screenshot
+                    ..portal
+                        .tx_conf
+                        .as_ref()
+                        .map(|tx| tx.borrow().screenshot.clone())
+                        .unwrap_or_default()
                 },
             ))
         }
@@ -783,7 +794,12 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
                 cosmic::task::message(crate::app::Msg::ConfigSetScreenshot(
                     config::screenshot::Screenshot {
                         save_location: loc,
-                        choice: (&mut portal.config.screenshot.choice).into(),
+                        choice: portal
+                            .tx_conf
+                            .as_ref()
+                            .map(|tx| tx.borrow().screenshot.choice.clone())
+                            .unwrap_or_default()
+                            .into(),
                     },
                 ))
             } else {

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -148,7 +148,7 @@ pub(crate) async fn process_changes(
                             .object_server()
                             .interface::<_, Background>(DBUS_PATH)
                             .await?;
-                        Background::running_applications_changed(background.signal_context())
+                        Background::running_applications_changed(background.signal_emitter())
                             .await?;
                     }
                     Event::Accent(a) => {

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use serde::Deserialize;
+use zbus::{zvariant, Result};
+
+static COSMIC_SCOPE: &str = "app-cosmic-";
+static FLATPAK_SCOPE: &str = "app-flatpak-";
+
+/// Proxy for the `org.freedesktop.systemd1.Manager` interface
+#[zbus::proxy(
+    default_service = "org.freedesktop.systemd1",
+    default_path = "/org/freedesktop/systemd1",
+    interface = "org.freedesktop.systemd1.Manager"
+)]
+pub trait Systemd1 {
+    fn list_units(&self) -> Result<Vec<Unit>>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, zvariant::Type)]
+#[cfg_attr(test, derive(Default))]
+#[zvariant(signature = "(ssssssouso)")]
+pub struct Unit {
+    pub name: String,
+    pub description: String,
+    pub load_state: LoadState,
+    pub active_state: ActiveState,
+    pub sub_state: SubState,
+    pub following: String,
+    pub unit_object: zvariant::OwnedObjectPath,
+    pub job_id: u32,
+    pub job_type: String,
+    pub job_object: zvariant::OwnedObjectPath,
+}
+
+impl Unit {
+    /// Returns appid if COSMIC or Flatpak launched this unit
+    pub fn cosmic_flatpak_name(&self) -> Option<&str> {
+        self.name
+            .strip_prefix(COSMIC_SCOPE)
+            .or_else(|| self.name.strip_prefix(FLATPAK_SCOPE))?
+            .rsplit_once('-')
+            .and_then(|(appid, pid_scope)| {
+                // Check if unit name ends in `-{PID}.scope`
+                _ = pid_scope.strip_suffix(".scope")?.parse::<u32>().ok()?;
+                Some(appid)
+            })
+    }
+}
+
+/// Load state for systemd units
+///
+/// Source: https://github.com/systemd/systemd/blob/main/man/systemctl.xml
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, zvariant::Type)]
+#[cfg_attr(test, derive(Default))]
+#[zvariant(signature = "s")]
+#[serde(rename_all = "kebab-case")]
+pub enum LoadState {
+    #[cfg_attr(test, default)]
+    Stub,
+    Loaded,
+    NotFound,
+    BadSetting,
+    Error,
+    Merged,
+    Masked,
+}
+
+/// Sub-state for systemd units
+///
+/// Source: https://github.com/systemd/systemd/blob/main/man/systemctl.xml
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, zvariant::Type)]
+#[cfg_attr(test, derive(Default))]
+#[zvariant(signature = "s")]
+#[serde(rename_all = "kebab-case")]
+pub enum SubState {
+    #[cfg_attr(test, default)]
+    Dead,
+    Active,
+    Waiting,
+    Running,
+    Failed,
+    Cleaning,
+    Tentative,
+    Plugged,
+    Mounting,
+    MountingDone,
+    Mounted,
+    Remounting,
+    Unmounting,
+    RemountingSigterm,
+    RemountingSigkill,
+    UnmountingSigterm,
+    UnmountingSigkill,
+    Stop,
+    StopWatchdog,
+    StopSigterm,
+    StopSigkill,
+    StartChown,
+    Abandoned,
+    Condition,
+    Start,
+    StartPre,
+    StartPost,
+    StopPre,
+    StopPreSigterm,
+    StopPreSigkill,
+    StopPost,
+    Exited,
+    Reload,
+    ReloadSignal,
+    ReloadNotify,
+    FinalWatchdog,
+    FinalSigterm,
+    FinalSigkill,
+    DeadBeforeAutoRestart,
+    FailedBeforeAutoRestart,
+    DeadResourcesPinned,
+    AutoRestart,
+    AutoRestartQueued,
+    Listening,
+    Activating,
+    ActivatingDone,
+    Deactivating,
+    DeactivatingSigterm,
+    DeactivatingSigkill,
+    Elapsed,
+}
+
+/// Activated state for systemd units
+///
+/// Source: https://github.com/systemd/systemd/blob/main/man/systemctl.xml
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, zvariant::Type)]
+#[cfg_attr(test, derive(Default))]
+#[zvariant(signature = "s")]
+#[serde(rename_all = "kebab-case")]
+pub enum ActiveState {
+    Active,
+    Reloading,
+    #[cfg_attr(test, default)]
+    Inactive,
+    Failed,
+    Activating,
+    Deactivating,
+    Maintenance,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Unit;
+
+    const APPID: &str = "com.system76.CosmicFiles";
+
+    fn unit_with_name(name: &str) -> Unit {
+        Unit {
+            name: name.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parse_appid_without_scope_fails() {
+        let unit = unit_with_name(APPID);
+        let name = unit.cosmic_flatpak_name();
+        assert!(
+            name.is_none(),
+            "Only apps launched by COSMIC or Flatpak should be parsed; got: {name:?}"
+        );
+    }
+
+    #[test]
+    fn parse_appid_with_scope_pid() {
+        let unit = unit_with_name(&format!("app-cosmic-{APPID}-1234.scope"));
+        let name = unit
+            .cosmic_flatpak_name()
+            .expect("Should parse app launched by COSMIC");
+        assert_eq!(APPID, name);
+    }
+
+    #[test]
+    fn parse_appid_with_scope_no_pid_fails() {
+        let unit = unit_with_name(&format!("app-cosmic-{APPID}.scope"));
+        let name = unit.cosmic_flatpak_name();
+        assert!(
+            name.is_none(),
+            "Apps launched by COSMIC/Flatpak should have a PID in its scope name"
+        );
+    }
+}

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -93,6 +93,7 @@ struct WaylandHelperInner {
     output_infos: Mutex<HashMap<wl_output::WlOutput, OutputInfo>>,
     output_toplevels: Mutex<HashMap<wl_output::WlOutput, Vec<ExtForeignToplevelHandleV1>>>,
     toplevels: Mutex<Vec<ToplevelInfo>>,
+    toplevel_update: Arc<(Mutex<bool>, Condvar)>,
     qh: QueueHandle<AppData>,
     capturer: Capturer,
     wl_shm: wl_shm::WlShm,
@@ -160,6 +161,12 @@ impl AppData {
 
         *self.wayland_helper.inner.toplevels.lock().unwrap() =
             self.toplevel_info_state.toplevels().cloned().collect();
+
+        // Signal that toplevels were updated; the actual updates are unimportant here
+        let (lock, cvar) = &*self.wayland_helper.inner.toplevel_update;
+        let mut updated = lock.lock().unwrap();
+        *updated = true;
+        cvar.notify_all();
     }
 }
 
@@ -246,6 +253,7 @@ impl WaylandHelper {
         let screencopy_state = ScreencopyState::new(&globals, &qh);
         let shm_state = Shm::bind(&globals, &qh).unwrap();
         let zwp_dmabuf = globals.bind(&qh, 4..=4, sctk::globals::GlobalData).unwrap();
+        let toplevel_update = Arc::new((Mutex::new(false), Condvar::new()));
         let wayland_helper = WaylandHelper {
             inner: Arc::new(WaylandHelperInner {
                 conn,
@@ -253,6 +261,7 @@ impl WaylandHelper {
                 output_infos: Mutex::new(HashMap::new()),
                 output_toplevels: Mutex::new(HashMap::new()),
                 toplevels: Mutex::new(Vec::new()),
+                toplevel_update,
                 qh: qh.clone(),
                 capturer: screencopy_state.capturer().clone(),
                 wl_shm: shm_state.wl_shm().clone(),
@@ -296,6 +305,10 @@ impl WaylandHelper {
 
     pub fn toplevels(&self) -> Vec<ToplevelInfo> {
         self.inner.toplevels.lock().unwrap().clone()
+    }
+
+    pub fn toplevel_signal(&self) -> Arc<(Mutex<bool>, Condvar)> {
+        Arc::clone(&self.inner.toplevel_update)
     }
 
     pub fn output_info(&self, output: &wl_output::WlOutput) -> Option<OutputInfo> {


### PR DESCRIPTION
**Requires the access portal to be enabled or else it does nothing**

I based my implementation on the [official specs](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.Background.html) as well as code from [GNOME](https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/blob/main/src/background.c), [KDE](https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/blob/master/src/background.cpp), [Xapp (Xfce)](https://github.com/linuxmint/xdg-desktop-portal-xapp/blob/master/src/background.c), and [Pantheon (elementary)](https://github.com/elementary/portals/blob/main/src/Background/Portal.vala). KDE's immaculately readable codebase served as this implementation's primary inspiration.

Like KDE, I intend to show a dialog, so the user may choose whether to grant privileges to an application. I will also provide an option to bypass the dialog for greater choice especially considering that GNOME [automatically grants permissions](https://github.com/flatpak/xdg-desktop-portal/discussions/1188).

~~According to the docs, the Autostart method is deprecated. However, I think I still need to implement it because background requests aren't routed to the COSMIC portal unless it's available.~~ **Autostart is implemented**

Closes: #49 