### PR TITLE
Improvements for screencast portal / dialog

### DIFF
--- a/cosmic-portal-config/src/screenshot.rs
+++ b/cosmic-portal-config/src/screenshot.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,6 +179,9 @@ impl cosmic::Application for CosmicPortal {
                 subscription::Event::Screencast(args) => {
                     screencast_dialog::update_args(self, args).map(cosmic::app::Message::App)
                 }
+                subscription::Event::CancelScreencast(handle) => {
+                    screencast_dialog::cancel(self, handle).map(cosmic::app::Message::App)
+                }
                 subscription::Event::Config(config) => self.update(Msg::ConfigSubUpdate(config)),
                 subscription::Event::Accent(_)
                 | subscription::Event::IsDark(_)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,5 @@
 use crate::{access, config, file_chooser, fl, screencast_dialog, screenshot, subscription};
 use cosmic::iced_core::event::wayland::OutputEvent;
-use cosmic::iced_core::keyboard::key::Named;
 use cosmic::widget::{self, dropdown};
 use cosmic::Command;
 use cosmic::{

--- a/src/file_chooser.rs
+++ b/src/file_chooser.rs
@@ -1,29 +1,15 @@
-use cosmic::{
-    app,
-    iced::{
-        wayland::actions::{layer_surface::SctkLayerSurfaceSettings, window::SctkWindowSettings},
-        widget::{column, row},
-        window, Length,
-    },
-    iced_core::Alignment,
-    iced_sctk::commands::{
-        layer_surface::{destroy_layer_surface, get_layer_surface},
-        window::{close_window, get_window},
-    },
-    widget,
-};
+use cosmic::{app, iced::window, widget};
 use cosmic_files::dialog::{
     DialogChoice, DialogChoiceOption, DialogFilter, DialogFilterPattern, DialogKind, DialogMessage,
     DialogResult,
 };
-use once_cell::sync::Lazy;
-use std::{ffi::OsString, os::unix::ffi::OsStringExt, path::PathBuf, sync::Arc};
+use std::{ffi::OsString, os::unix::ffi::OsStringExt, path::PathBuf};
 use tokio::sync::mpsc::Sender;
 use zbus::zvariant;
 
 use crate::{
     app::{CosmicPortal, Msg as AppMsg},
-    fl, subscription, PortalResponse,
+    subscription, PortalResponse,
 };
 
 pub(crate) type Dialog = cosmic_files::dialog::Dialog<Msg>;
@@ -36,6 +22,7 @@ type Filters = Vec<Filter>;
 #[zvariant(signature = "a{sv}")]
 pub struct OpenFileOptions {
     accept_label: Option<String>,
+    #[allow(dead_code)]
     modal: Option<bool>,
     multiple: Option<bool>,
     directory: Option<bool>,
@@ -49,12 +36,14 @@ pub struct OpenFileOptions {
 #[zvariant(signature = "a{sv}")]
 pub struct SaveFileOptions {
     accept_label: Option<String>,
+    #[allow(dead_code)]
     modal: Option<bool>,
     filters: Option<Filters>,
     current_filter: Option<Filter>,
     choices: Option<Choices>,
     current_name: Option<String>,
     current_folder: Option<Vec<u8>>,
+    #[allow(dead_code)]
     current_file: Option<Vec<u8>>,
 }
 
@@ -62,9 +51,11 @@ pub struct SaveFileOptions {
 #[zvariant(signature = "a{sv}")]
 pub struct SaveFilesOptions {
     accept_label: Option<String>,
+    #[allow(dead_code)]
     modal: Option<bool>,
     choices: Option<Choices>,
     current_folder: Option<Vec<u8>>,
+    #[allow(dead_code)]
     files: Option<Vec<Vec<u8>>>,
 }
 
@@ -108,6 +99,7 @@ impl FileChooserOptions {
         }
     }
 
+    #[allow(dead_code)]
     fn modal(&self) -> bool {
         // Defaults to true
         match self {
@@ -189,7 +181,6 @@ impl FileChooser {
 impl FileChooser {
     async fn open_file(
         &self,
-        #[zbus(connection)] connection: &zbus::Connection,
         handle: zvariant::ObjectPath<'_>,
         app_id: &str,
         parent_window: &str,
@@ -208,7 +199,6 @@ impl FileChooser {
 
     async fn save_file(
         &self,
-        #[zbus(connection)] connection: &zbus::Connection,
         handle: zvariant::ObjectPath<'_>,
         app_id: &str,
         parent_window: &str,
@@ -227,7 +217,6 @@ impl FileChooser {
 
     async fn save_files(
         &self,
-        #[zbus(connection)] connection: &zbus::Connection,
         handle: zvariant::ObjectPath<'_>,
         app_id: &str,
         parent_window: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use cosmic::cosmic_theme::palette::Srgba;
+use futures::future::AbortHandle;
 use std::collections::HashMap;
 use zbus::zvariant::{self, OwnedValue};
 
@@ -51,11 +52,13 @@ impl<T: zvariant::Type + serde::Serialize> serde::Serialize for PortalResponse<T
     }
 }
 
-struct Request;
+struct Request(AbortHandle);
 
 #[zbus::interface(name = "org.freedesktop.impl.portal.Request")]
 impl Request {
-    fn close(&self) {}
+    fn close(&self) {
+        self.0.abort();
+    }
 }
 
 struct Session {

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -5,11 +5,7 @@ use futures::{
     future::abortable,
     stream::{FuturesOrdered, StreamExt},
 };
-use std::{
-    collections::HashMap,
-    mem,
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, mem};
 use tokio::sync::mpsc::Sender;
 use zbus::zvariant;
 
@@ -157,7 +153,7 @@ impl ScreenCast {
         };
 
         // XXX
-        let mut outputs = self.wayland_helper.outputs();
+        let outputs = self.wayland_helper.outputs();
         if outputs.is_empty() {
             log::error!("No output");
             return PortalResponse::Other;
@@ -224,8 +220,7 @@ impl ScreenCast {
         }
 
         // Session may have already been cancelled
-        let mut session_data = interface.get_mut().await;
-        if session_data.closed {
+        if interface.get().await.closed {
             for thread in screencast_threads {
                 thread.stop();
             }

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -174,6 +174,7 @@ impl ScreenCast {
         // Show dialog to prompt for what to capture
         let (abortable, abort_handle) = abortable(screencast_dialog::show_screencast_prompt(
             &self.tx,
+            session_handle.to_owned(),
             app_id,
             multiple,
             source_types,

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -1,4 +1,4 @@
-use crate::app::{CosmicPortal, OutputState};
+use crate::app::CosmicPortal;
 use crate::fl;
 use crate::wayland::{CaptureSource, WaylandHelper};
 use crate::widget::{keyboard_wrapper::KeyboardWrapper, screenshot::MyImage};
@@ -7,7 +7,7 @@ use cosmic::desktop::IconSource;
 use cosmic::iced::{
     self,
     keyboard::{key::Named, Key},
-    window, Limits,
+    window,
 };
 use cosmic::iced_runtime::command::platform_specific::wayland::layer_surface::SctkLayerSurfaceSettings;
 use cosmic::iced_sctk::commands::layer_surface::{
@@ -20,7 +20,6 @@ use cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::Zco
 use freedesktop_desktop_entry as fde;
 use freedesktop_desktop_entry::{get_languages_from_env, DesktopEntry};
 use once_cell::sync::Lazy;
-use std::fs;
 use std::mem;
 use std::sync::Arc;
 use tokio::sync::mpsc;

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -16,7 +16,7 @@ use pipewire::{
 };
 use std::{ffi::c_void, io, iter, os::fd::IntoRawFd, slice};
 use tokio::sync::oneshot;
-use wayland_client::protocol::{wl_buffer, wl_output, wl_shm};
+use wayland_client::protocol::{wl_buffer, wl_shm};
 
 use crate::{
     buffer,

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -21,7 +21,7 @@ pub enum Event {
     Access(crate::access::AccessDialogArgs),
     FileChooser(crate::file_chooser::Args),
     Screenshot(crate::screenshot::Args),
-    Screencast(crate::screencast_dialog::Args),
+    Screencast(Option<crate::screencast_dialog::Args>),
     Accent(Srgba),
     IsDark(bool),
     HighContrast(bool),

--- a/src/widget/keyboard_wrapper.rs
+++ b/src/widget/keyboard_wrapper.rs
@@ -1,9 +1,8 @@
 use cosmic::{
-    iced::Limits,
     iced_core::{
         event::{self, Event},
-        keyboard, layout, mouse, overlay, renderer, touch,
-        widget::{tree, Operation, Tree},
+        keyboard, layout, mouse, overlay, renderer,
+        widget::{Operation, Tree},
         Clipboard, Element, Layout, Length, Rectangle, Shell, Size, Widget,
     },
     iced_renderer::core::widget::OperationOutputWrapper,


### PR DESCRIPTION
Now the dialog is closed if the screencast request in cancelled over dbus. And the dialog is correctly updated if a request is made while the dialog is already running. This also makes some general code improvements.

The behavior of screen capture on Chromium, which is a bit weird given duplication with Chromium's own dialog, now seems to be more correct and match Gnome.

More changes will be needed to make sure `Request` and `Session` works exactly like they should (handling session `close` requests while dialog is running, emitting `closed`, etc.), but that doesn't seem to be too crucial.