### PR TITLE
WIP Remote Desktop Portal

### DIFF
--- a/data/cosmic.portal
+++ b/data/cosmic.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.cosmic
-Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.ScreenCast
+Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.ScreenCast
 UseIn=cosmic

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod buffer;
 mod documents;
 mod file_chooser;
 mod localize;
+mod remote_desktop;
 mod screencast;
 mod screencast_dialog;
 mod screencast_thread;

--- a/src/remote_desktop.rs
+++ b/src/remote_desktop.rs
@@ -1,0 +1,115 @@
+use crate::{PortalResponse, Session};
+use std::{
+    collections::HashMap,
+    env,
+    os::{fd::OwnedFd, unix::net::UnixStream},
+};
+use zbus::zvariant;
+
+#[derive(zvariant::SerializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+struct CreateSessionResult {
+    session_id: String,
+}
+
+#[derive(zvariant::DeserializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+struct SelectDevicesOptions {
+    // Default: all
+    types: Option<u32>,
+    restore_data: Option<(String, u32, zvariant::OwnedValue)>,
+    // Default: 0
+    persist_mode: Option<u32>,
+}
+
+#[derive(zvariant::SerializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+struct StartResult {
+    devices: u32,
+    clipboard_enabled: bool,
+    streams: Vec<(u32, HashMap<String, zvariant::OwnedValue>)>,
+}
+
+struct SessionData {}
+
+pub struct RemoteDesktop;
+
+#[zbus::interface(name = "org.freedesktop.impl.portal.RemoteDesktop")]
+impl RemoteDesktop {
+    async fn create_session(
+        &self,
+        #[zbus(connection)] connection: &zbus::Connection,
+        handle: zvariant::ObjectPath<'_>,
+        session_handle: zvariant::ObjectPath<'_>,
+        app_id: String,
+        options: HashMap<String, zvariant::OwnedValue>,
+    ) -> PortalResponse<CreateSessionResult> {
+        connection
+            .object_server()
+            .at(&session_handle, Session::new(SessionData {}, |_| {}))
+            .await
+            .unwrap(); // XXX unwrap
+        PortalResponse::Success(CreateSessionResult {
+            session_id: "foo".to_string(), // XXX
+        })
+    }
+
+    // CreateSession
+    async fn select_devices(
+        &self,
+        #[zbus(connection)] connection: &zbus::Connection,
+        handle: zvariant::ObjectPath<'_>,
+        session_handle: zvariant::ObjectPath<'_>,
+        app_id: String,
+        options: SelectDevicesOptions, // XXX
+    ) -> PortalResponse<HashMap<String, zvariant::OwnedValue>> {
+        PortalResponse::Success(HashMap::new())
+    }
+
+    async fn start(
+        &self,
+        #[zbus(connection)] connection: &zbus::Connection,
+        handle: zvariant::ObjectPath<'_>,
+        session_handle: zvariant::ObjectPath<'_>,
+        app_id: String,
+        parent_window: String,
+        options: HashMap<String, zvariant::OwnedValue>,
+    ) -> PortalResponse<StartResult> {
+        PortalResponse::Success(StartResult {
+            devices: 7,
+            clipboard_enabled: false,
+            streams: Vec::new(),
+        })
+    }
+
+    async fn connect_to_EIS(
+        &self,
+        #[zbus(connection)] connection: &zbus::Connection,
+        session_handle: zvariant::ObjectPath<'_>,
+        app_id: String,
+        options: HashMap<String, zvariant::OwnedValue>,
+    ) -> zvariant::Fd {
+        println!("Connect");
+        // TODO Dedicated mechanism to get fd, for specific "devices"
+        if let Ok(path) = env::var("LIBEI_SOCKET") {
+            if let Ok(socket) = UnixStream::connect(path) {
+                return OwnedFd::from(socket).into();
+            }
+        }
+
+        todo!()
+        //PortalResponse::Other
+    }
+
+    // TODO: Notify*
+
+    #[zbus(property)]
+    async fn available_device_types(&self) -> u32 {
+        7 // XXX
+    }
+
+    #[zbus(property, name = "version")]
+    async fn version(&self) -> u32 {
+        2
+    }
+}

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -11,9 +11,9 @@ use tokio::sync::mpsc::Receiver;
 use zbus::{zvariant, Connection};
 
 use crate::{
-    access::Access, config, file_chooser::FileChooser, screencast::ScreenCast,
-    screenshot::Screenshot, wayland, ColorScheme, Contrast, Settings, ACCENT_COLOR_KEY,
-    APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY, CONTRAST_KEY, DBUS_NAME, DBUS_PATH,
+    access::Access, config, file_chooser::FileChooser, remote_desktop::RemoteDesktop,
+    screencast::ScreenCast, screenshot::Screenshot, wayland, ColorScheme, Contrast, Settings,
+    ACCENT_COLOR_KEY, APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY, CONTRAST_KEY, DBUS_NAME, DBUS_PATH,
 };
 
 #[derive(Clone)]
@@ -137,6 +137,7 @@ pub(crate) async fn process_changes(
                 .name(DBUS_NAME)?
                 .serve_at(DBUS_PATH, Access::new(wayland_helper.clone(), tx.clone()))?
                 .serve_at(DBUS_PATH, FileChooser::new(tx.clone()))?
+                .serve_at(DBUS_PATH, RemoteDesktop)?
                 .serve_at(
                     DBUS_PATH,
                     Screenshot::new(wayland_helper.clone(), tx.clone()),


### PR DESCRIPTION
Requires https://github.com/pop-os/cosmic-comp/pull/465.

This is the minimal require for a client that uses the portal to get a libei fd.

I guess we need a secure mechanism to get a  libei fd for a specific device bitflag field, and this should implement the legacy non-ei methods by lazily connecting to an ei socket if they are used? This will also need a dialog.