### PR TITLE
Dialog improvements

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -5,11 +5,12 @@ use cosmic::iced_runtime::platform_specific::wayland::layer_surface::{
 };
 use cosmic::iced_winit::commands::layer_surface::{destroy_layer_surface, get_layer_surface};
 use cosmic::widget::autosize::autosize;
-use cosmic::widget::{button, container, dropdown, horizontal_space, icon, text, Id, Row};
+use cosmic::widget::{self, button, dropdown, icon, text, Column, Id};
 use cosmic::{
     iced::{
-        widget::{column, row},
-        window, Length,
+        keyboard::{key::Named, Key},
+        widget::column,
+        window,
     },
     iced_core::Alignment,
 };
@@ -17,6 +18,7 @@ use tokio::sync::mpsc::Sender;
 use zbus::zvariant;
 
 use crate::wayland::WaylandHelper;
+use crate::widget::keyboard_wrapper::KeyboardWrapper;
 use crate::{app::CosmicPortal, fl};
 use crate::{subscription, PortalResponse};
 
@@ -163,52 +165,53 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
     for (i, choice) in choices.iter().enumerate() {
         options.push(dropdown(choice.1.as_slice(), choice.0, move |j| Msg::Choice(i, j)).into());
     }
-    options.push(horizontal_space().width(Length::Fill).into());
-    options.push(
-        button::text(
+
+    let options = Column::with_children(options)
+        .spacing(spacing.space_xxs as f32) // space_l
+        .align_x(Alignment::Center);
+
+    let icon = icon::Icon::from(
+        icon::from_name(
             args.options
-                .deny_label
-                .clone()
-                .unwrap_or_else(|| fl!("cancel")),
+                .icon
+                .as_ref()
+                .map_or("image-missing", |name| name.as_str()),
         )
-        .on_press(Msg::Cancel)
-        .into(),
-    );
-    options.push(
-        button::text(
-            args.options
-                .grant_label
-                .clone()
-                .unwrap_or_else(|| fl!("allow")),
-        )
-        .on_press(Msg::Allow)
-        .class(cosmic::theme::Button::Suggested)
-        .into(),
+        .size(64),
     );
 
-    let content = container(
-        column![
-            row![
-                icon::Icon::from(
-                    icon::from_name(
-                        args.options
-                            .icon
-                            .as_ref()
-                            .map_or("image-missing", |name| name.as_str())
-                    )
-                    .size(64)
-                )
-                .width(Length::Fixed(64.0))
-                .height(Length::Fixed(64.0)), // TODO icon for the dialog
-                text(args.title.as_str()),
-                text(args.subtitle.as_str()),
-                text(args.body.as_str()),
-            ],
-            Row::with_children(options)
-                .spacing(spacing.space_xxs as f32) // space_l
-                .align_y(Alignment::Center),
-        ]
-        .spacing(spacing.space_l as f32), // space_l
+    let control = column![text(args.body.as_str()), options].spacing(spacing.space_m as f32);
+
+    let cancel_button = button::text(
+        args.options
+            .deny_label
+            .clone()
+            .unwrap_or_else(|| fl!("cancel")),
+    )
+    .on_press(Msg::Cancel);
+
+    let allow_button = button::text(
+        args.options
+            .grant_label
+            .clone()
+            .unwrap_or_else(|| fl!("allow")),
+    )
+    .on_press(Msg::Allow)
+    .class(cosmic::theme::Button::Suggested);
+
+    let content = KeyboardWrapper::new(
+        widget::dialog()
+            .title(&args.title)
+            .body(&args.subtitle)
+            .control(control)
+            .icon(icon)
+            .secondary_action(cancel_button)
+            .primary_action(allow_button),
+        |key| match key {
+            Key::Named(Named::Enter) => Some(Msg::Allow),
+            Key::Named(Named::Escape) => Some(Msg::Cancel),
+            _ => None,
+        },
     );
 
     if args.autosize {

--- a/src/access.rs
+++ b/src/access.rs
@@ -97,7 +97,6 @@ impl Access {
                 choice_labels,
                 tx,
                 access_id: window::Id::NONE,
-                autosize: false,
             }))
             .await
         {
@@ -132,7 +131,6 @@ pub(crate) struct AccessDialogArgs {
     pub choice_labels: Vec<Vec<String>>,
     pub tx: Sender<PortalResponse<AccessDialogResult>>,
     pub access_id: window::Id,
-    pub autosize: bool,
 }
 
 impl AccessDialogArgs {
@@ -143,13 +141,11 @@ impl AccessDialogArgs {
                 resizable: false,
                 ..Default::default()
             });
-            self.autosize = true;
             self.access_id = id;
             task.map(|_| Msg::Ignore)
         } else {
             // create a layer surface
             self.access_id = window::Id::unique();
-            self.autosize = false;
             get_layer_surface(SctkLayerSurfaceSettings {
                 id: self.access_id,
                 layer: cosmic_client_toolkit::sctk::shell::wlr_layer::Layer::Top,
@@ -241,14 +237,10 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
         },
     );
 
-    if args.autosize {
-        autosize(content, Id::new(args.app_id.clone()))
-            .min_width(1.)
-            .min_height(1.)
-            .into()
-    } else {
-        content.into()
-    }
+    autosize(content, Id::new(args.app_id.clone()))
+        .min_width(1.)
+        .min_height(1.)
+        .into()
 }
 
 pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::app::Msg> {

--- a/src/access.rs
+++ b/src/access.rs
@@ -100,7 +100,7 @@ pub enum Msg {
     Ignore,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct AccessDialogArgs {
     pub handle: zvariant::ObjectPath<'static>,
     pub app_id: String,

--- a/src/access.rs
+++ b/src/access.rs
@@ -49,7 +49,7 @@ impl Access {
     }
 }
 
-#[zbus::interface(name = "")]
+#[zbus::interface(name = "org.freedesktop.impl.portal.Access")]
 impl Access {
     #[allow(clippy::too_many_arguments)]
     async fn access_dialog(

--- a/src/access.rs
+++ b/src/access.rs
@@ -9,11 +9,12 @@ use cosmic::widget::{self, button, dropdown, icon, text, Column, Id};
 use cosmic::{
     iced::{
         keyboard::{key::Named, Key},
-        widget::column,
+        widget::{column, row},
         window,
     },
     iced_core::Alignment,
 };
+use std::collections::HashMap;
 use tokio::sync::mpsc::Sender;
 use zbus::zvariant;
 
@@ -68,6 +69,20 @@ impl Access {
         // await response via channel
         log::debug!("Access dialog {app_id} {parent_window} {title} {subtitle} {body} {options:?}");
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        // `widget::dialog` needs a slice of labels
+        let choice_labels: Vec<Vec<String>> = options
+            .choices
+            .iter()
+            .flatten()
+            .map(|(_, _, choices, _)| choices.iter().map(|(_, label)| label.clone()).collect())
+            .collect();
+        let active_choices = options
+            .choices
+            .iter()
+            .flatten()
+            .map(|(id, _, _, initial)| (id.clone(), initial.clone()))
+            .filter(|(_, value)| !value.is_empty())
+            .collect();
         if let Err(err) = self
             .tx
             .send(subscription::Event::Access(AccessDialogArgs {
@@ -78,6 +93,8 @@ impl Access {
                 subtitle: subtitle.to_string(),
                 body: body.to_string(),
                 options,
+                active_choices,
+                choice_labels,
                 tx,
                 access_id: window::Id::NONE,
                 autosize: false,
@@ -111,6 +128,8 @@ pub(crate) struct AccessDialogArgs {
     pub subtitle: String,
     pub body: String,
     pub options: AccessDialogOptions,
+    pub active_choices: HashMap<String, String>,
+    pub choice_labels: Vec<Vec<String>>,
     pub tx: Sender<PortalResponse<AccessDialogResult>>,
     pub access_id: window::Id,
     pub autosize: bool,
@@ -160,10 +179,18 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<Msg> {
         return text("Oops, no access dialog args").into();
     };
 
-    let choices = &portal.access_choices;
-    let mut options = Vec::with_capacity(choices.len() + 3);
-    for (i, choice) in choices.iter().enumerate() {
-        options.push(dropdown(choice.1.as_slice(), choice.0, move |j| Msg::Choice(i, j)).into());
+    let choices = &args.options.choices.as_deref().unwrap_or(&[]);
+    let mut options = Vec::with_capacity(choices.len());
+    for (i, ((id, label, choices, initial), choice_labels)) in
+        choices.iter().zip(&args.choice_labels).enumerate()
+    {
+        let label = text(label);
+        let active_choice = args
+            .active_choices
+            .get(id)
+            .and_then(|choice_id| choices.iter().position(|(x, _)| x == choice_id));
+        let dropdown = dropdown(&choice_labels, active_choice, move |j| Msg::Choice(i, j));
+        options.push(row![label, dropdown].into());
     }
 
     let options = Column::with_children(options)
@@ -229,11 +256,10 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
         Msg::Allow => {
             let args = portal.access_args.take().unwrap();
             let tx = args.tx.clone();
+            let choices = args.active_choices.clone().into_iter().collect();
             tokio::spawn(async move {
-                tx.send(PortalResponse::Success(AccessDialogResult {
-                    choices: vec![],
-                }))
-                .await
+                tx.send(PortalResponse::Success(AccessDialogResult { choices }))
+                    .await
             });
 
             args.destroy_surface()
@@ -250,7 +276,12 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
         }
         Msg::Choice(i, j) => {
             let args = portal.access_args.as_mut().unwrap();
-            portal.access_choices[i].0 = Some(j);
+            if let Some(choice) = args.options.choices.as_ref().and_then(|x| x.get(i)) {
+                if let Some((option_id, _)) = choice.2.get(j) {
+                    args.active_choices
+                        .insert(choice.0.clone(), option_id.clone());
+                }
+            }
             cosmic::iced::Task::none()
         }
         Msg::Ignore => cosmic::iced::Task::none(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,7 +31,6 @@ pub struct CosmicPortal {
     pub config: config::Config,
 
     pub access_args: Option<access::AccessDialogArgs>,
-    pub access_choices: Vec<(Option<usize>, Vec<String>)>,
 
     pub file_choosers: HashMap<window::Id, (file_chooser::Args, file_chooser::Dialog)>,
 
@@ -128,7 +127,6 @@ impl cosmic::Application for CosmicPortal {
                 config_handler,
                 config,
                 access_args: Default::default(),
-                access_choices: Default::default(),
                 file_choosers: Default::default(),
                 screenshot_args: Default::default(),
                 screencast_args: Default::default(),

--- a/src/file_chooser.rs
+++ b/src/file_chooser.rs
@@ -240,7 +240,7 @@ pub enum Msg {
     DialogResult(DialogResult),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Args {
     pub handle: zvariant::ObjectPath<'static>,
     pub app_id: String,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -17,7 +17,7 @@ use image::RgbaImage;
 use rustix::fd::AsFd;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
-use std::{collections::HashMap, fmt::Debug, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 use tokio::sync::mpsc::Sender;
 
 use wayland_client::protocol::wl_output::WlOutput;
@@ -385,7 +385,7 @@ pub enum Action {
     Choice(Choice),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Args {
     pub handle: zvariant::ObjectPath<'static>,
     pub app_id: String,
@@ -399,7 +399,6 @@ pub struct Args {
     pub action: Action,
 }
 
-#[derive(Clone, Debug)]
 struct Output {
     output: WlOutput,
     logical_position: (i32, i32),

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -1,9 +1,6 @@
 // contains the subscription which sends portal events and response channels to iced.
 
-use std::{
-    any::TypeId,
-    fmt::{Debug, Formatter},
-};
+use std::any::TypeId;
 
 use cosmic::{cosmic_theme::palette::Srgba, iced::Subscription};
 use futures::{future, SinkExt};
@@ -16,7 +13,7 @@ use crate::{
     APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY, CONTRAST_KEY, DBUS_NAME, DBUS_PATH,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Event {
     Access(crate::access::AccessDialogArgs),
     FileChooser(crate::file_chooser::Args),
@@ -28,61 +25,6 @@ pub enum Event {
     HighContrast(bool),
     Config(config::Config),
     Init(tokio::sync::mpsc::Sender<Event>),
-}
-
-impl Debug for Event {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Event::Access(args) => f
-                .debug_struct("Access")
-                .field("title", &args.title)
-                .field("subtitle", &args.subtitle)
-                .field("body", &args.body)
-                .field("options", &args.options)
-                .field("app_id", &args.app_id)
-                .field("parent_window", &args.parent_window)
-                .field("handle", &args.handle)
-                .finish(),
-            Event::FileChooser(args) => f
-                .debug_struct("FileChooser")
-                .field("handle", &args.handle)
-                .field("app_id", &args.app_id)
-                .field("parent_window", &args.parent_window)
-                .field("title", &args.title)
-                .field("options", &args.options)
-                .finish(),
-            Event::Screenshot(crate::screenshot::Args {
-                handle,
-                app_id,
-                parent_window,
-                options,
-                output_images: images,
-                choice,
-                action,
-                location,
-                tx: _tx,
-                toplevel_images,
-            }) => f
-                .debug_struct("Screenshot")
-                .field("handle", handle)
-                .field("app_id", app_id)
-                .field("parent_window", parent_window)
-                .field("images", &images.keys().collect::<Vec<_>>())
-                .field("options", options)
-                .field("choice", choice)
-                .field("action", action)
-                .field("location", location)
-                .field("toplevel_images", toplevel_images)
-                .finish(),
-            Event::Screencast(s) => s.fmt(f),
-            Event::CancelScreencast(h) => f.debug_tuple("CancelScreencast").field(h).finish(),
-            Event::Accent(a) => a.fmt(f),
-            Event::IsDark(t) => t.fmt(f),
-            Event::HighContrast(c) => c.fmt(f),
-            Event::Config(c) => c.fmt(f),
-            Event::Init(tx) => tx.fmt(f),
-        }
-    }
 }
 
 pub enum State {


### PR DESCRIPTION
May as well create a PR for some changes I've been working on, but more (larger) changes will be added later.

Apparently the access portal should be used for non-interactive screenshots, but that doesn't currently happen since `version` isn't advertised properly. That will also require the change from https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/88, and fixing up the `view` of the access dialog.

Not done yet (in the initial version of this PR):

* Make sure cancelling a request closes any dialog related to that request, for all dialogs
* Clean up and de-duplicate some of the dialog related code now that we have multiple dialogs
* Fix the access dialog
* Figure out how to handle portal requests to create a dialog when another dialog is open
  - Does `xdg-desktop-portal` handle this for us? What do other portals do?