### PR TITLE
Made Cursor Show By Default If Client Doesn't Request The Cursor Mode

### DIFF
--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -146,7 +146,7 @@ impl ScreenCast {
 
         let (cursor_mode, multiple, source_types) = {
             let session_data = interface.get_mut().await;
-            let cursor_mode = session_data.cursor_mode.unwrap_or(CURSOR_MODE_HIDDEN);
+            let cursor_mode = session_data.cursor_mode.unwrap_or(CURSOR_MODE_EMBEDDED);
             let multiple = session_data.multiple;
             let source_types = session_data.source_types;
             (cursor_mode, multiple, source_types)


### PR DESCRIPTION
Within most DEs/WMs, the default handling of cursors when using the ScreenCast protocol is that if the client does not request any, it defaults to showing the cursor.\
Currently, Cosmic is not doing that, causing the cursor to not appear on apps which do not implement this part of the spec (such as Chromium) causing the cursor to be missing when screen sharing.

This is a simple one-line PR just to change the defaults so the cursor can be seen :)