### PR TITLE
Check For Existence Of A Screenshot's Parent Folder

### DIFF
--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -184,6 +184,13 @@ impl Screenshot {
     }
 
     pub fn save_rgba(img: &RgbaImage, path: &PathBuf) -> anyhow::Result<()> {
+        let path_parent = path
+            .parent()
+            .expect("Unable to get the screenshot file's parent directory");
+        if !path_parent.exists() {
+            std::fs::create_dir_all(path_parent)?;
+        }
+
         let mut encoder =
             png::Encoder::new(std::fs::File::create(path)?, img.width(), img.height());
         encoder.set_color(png::ColorType::Rgba);


### PR DESCRIPTION
When Cosmic is first installed on a new computer, certain folders (such as the Documents or Pictures folders) won't exist by default. If no other app creates them, then there is a chance that they just won't exist at all, causing screenshots to fail to save.

This PR just adds a check to see if the location that the screenshot will be saved to is valid, and if not, then create that folder.