### PR TITLE
screenshot: indicate correct version

### DIFF
--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -511,7 +511,9 @@ impl Screenshot {
 
     #[zbus(property)]
     fn version(&self) -> u32 {
-        2
+        //TODO: increase version when color picking is implemented
+        // return 1 to indicate that the portal only supports screenshots, not color picking
+        1
     }
 }
 


### PR DESCRIPTION
Return version `1` for the screenshot portal to indicate that the `PickColor` method is not yet fully supported. This will allow clients to properly check and handle the missing method.

Ref: https://github.com/flatpak/xdg-desktop-portal/pull/766