### PR TITLE
fix(data): Expect an upper-case value in `XDG_CURRENT_DESKTOP`

### DIFF
--- a/data/cosmic.portal
+++ b/data/cosmic.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.cosmic
 Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.ScreenCast
-UseIn=cosmic
+UseIn=COSMIC


### PR DESCRIPTION
cosmic-session sets the `XDG_CURRENT_DESKTOP` variable to `COSMIC`. But the `cosmic.portal` file was expecting a lower-case `cosmic` value. That resulted in the portal not being launched.

Overwriting `XDG_CURRENT_DESKTOP` to `cosmic` was reported as a workaround by people facing the issue[0][1], but it's not a correct fix, since many other COSMIC subprojects are relying on the upper-case value. The right thing to do is to expect `COSMIC`, for consistency.

Fixes pop-os/xdg-desktop-portal-cosmic#93

[0] https://aur.archlinux.org/packages/cosmic-screenshot-git#comment-980452
[1] pop-os/cosmic-screenshot#3