### PR TITLE
Fixes for handling of transform/scale in screencopy/screencast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7669,6 +7669,7 @@ dependencies = [
  "memmap2 0.9.5",
  "once_cell",
  "pipewire",
+ "pipewire-sys",
  "png",
  "rust-embed",
  "rustix 0.38.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ png = "0.17.5"
 rustix = { version = "0.38.0", features = ["fs"] }
 # spa_sys = { package = "libspa-sys", git = "https://github.com/pop-os/pipewire-rs" }
 spa_sys = { package = "libspa-sys", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
+pipewire-sys = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
 tempfile = "3.5.0"
 tokio = { version = "1.19.2", features = ["macros", "net", "rt", "sync"] }
 wayland-client = { version = "0.31.1" }

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -86,7 +86,7 @@ pub async fn show_screencast_prompt(
         let image = wayland_helper
             .capture_source_shm(source, false)
             .await
-            .and_then(|image| image.image().ok())
+            .and_then(|image| image.image_transformed().ok())
             .map(|image| {
                 widget::image::Handle::from_rgba(image.width(), image.height(), image.into_vec())
             });

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -13,14 +13,14 @@ use cosmic::iced_runtime::platform_specific::wayland::layer_surface::{
 use cosmic::iced_winit::commands::layer_surface::{destroy_layer_surface, get_layer_surface};
 use cosmic::widget::horizontal_space;
 use cosmic_client_toolkit::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
-use image::{imageops, RgbaImage};
+use image::RgbaImage;
 use rustix::fd::AsFd;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
 use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 use tokio::sync::mpsc::Sender;
 
-use wayland_client::protocol::wl_output::{self, Transform, WlOutput};
+use wayland_client::protocol::wl_output::{self, WlOutput};
 use zbus::zvariant;
 
 use crate::app::{CosmicPortal, OutputState};
@@ -171,15 +171,9 @@ impl Screenshot {
                 .ok_or_else(|| anyhow::anyhow!("shm screencopy failed"))?;
             map.insert(
                 name,
-                frame.image().map(|mut img| {
-                    img = match frame.transform {
-                        Transform::_90 => imageops::rotate90(&img),
-                        Transform::_180 => imageops::rotate180(&img),
-                        Transform::_270 => imageops::rotate270(&img),
-                        _ => img,
-                    };
-                    (img.width(), img.height(), img.into_vec().into())
-                })?,
+                frame
+                    .image_transformed()
+                    .map(|img| (img.width(), img.height(), img.into_vec().into()))?,
             );
         }
 

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -145,7 +145,7 @@ impl Screenshot {
                 .capture_output_toplevels_shm(&output, false)
                 .await
                 .into_iter()
-                .filter_map(|img| img.image().ok())
+                .filter_map(|img| img.image_transformed().ok())
                 .map(|img| (img.width(), img.height(), img.into_vec().into()))
                 .collect();
             map.insert(name.clone(), frame);
@@ -270,7 +270,7 @@ impl Screenshot {
                     .unwrap_or_default();
                 let mut image = image::RgbaImage::new(width, height);
                 for (frame, rect) in frames {
-                    let frame_image = frame.image()?;
+                    let frame_image = frame.image_transformed()?;
                     image::imageops::overlay(
                         &mut image,
                         &frame_image,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -242,6 +242,7 @@ impl Screenshot {
             for Output {
                 output,
                 logical_position: (output_x, output_y),
+                logical_size: (output_w, output_h),
                 ..
             } in outputs
             {
@@ -252,8 +253,8 @@ impl Screenshot {
                 let rect = Rect {
                     left: output_x,
                     top: output_y,
-                    right: output_x.saturating_add(frame.width.try_into().unwrap_or_default()),
-                    bottom: output_y.saturating_add(frame.height.try_into().unwrap_or_default()),
+                    right: output_x.saturating_add(output_w.try_into().unwrap_or_default()),
+                    bottom: output_y.saturating_add(output_h.try_into().unwrap_or_default()),
                 };
                 bounds_opt = Some(match bounds_opt.take() {
                     Some(bounds) => Rect {
@@ -281,7 +282,15 @@ impl Screenshot {
                     .unwrap_or_default();
                 let mut image = image::RgbaImage::new(width, height);
                 for (frame, rect) in frames {
+                    let width = (rect.right - rect.left) as u32;
+                    let height = (rect.bottom - rect.top) as u32;
                     let frame_image = frame.image_transformed()?;
+                    let frame_image = image::imageops::resize(
+                        &frame_image,
+                        width,
+                        height,
+                        image::imageops::FilterType::Lanczos3,
+                    );
                     image::imageops::overlay(
                         &mut image,
                         &frame_image,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -12,7 +12,6 @@ use cosmic::iced_runtime::platform_specific::wayland::layer_surface::{
 };
 use cosmic::iced_winit::commands::layer_surface::{destroy_layer_surface, get_layer_surface};
 use cosmic::widget::horizontal_space;
-use cosmic_client_toolkit::sctk::output::OutputInfo;
 use cosmic_client_toolkit::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
 use image::{imageops, RgbaImage};
 use rustix::fd::AsFd;
@@ -173,19 +172,10 @@ impl Screenshot {
             map.insert(
                 name,
                 frame.image().map(|mut img| {
-                    img = match wayland_helper.output_info(&output) {
-                        Some(OutputInfo {
-                            transform: Transform::_90,
-                            ..
-                        }) => imageops::rotate90(&img),
-                        Some(OutputInfo {
-                            transform: Transform::_180,
-                            ..
-                        }) => imageops::rotate180(&img),
-                        Some(OutputInfo {
-                            transform: Transform::_270,
-                            ..
-                        }) => imageops::rotate270(&img),
+                    img = match frame.transform {
+                        Transform::_90 => imageops::rotate90(&img),
+                        Transform::_180 => imageops::rotate180(&img),
+                        Transform::_270 => imageops::rotate270(&img),
                         _ => img,
                     };
                     (img.width(), img.height(), img.into_vec().into())

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -414,8 +414,17 @@ impl WaylandHelper {
         let res = session.capture_wl_buffer(&buffer).await;
         buffer.destroy();
 
-        if res.is_ok() {
-            Some(ShmImage { fd, width, height })
+        if let Ok(frame) = res {
+            let transform = match frame.transform {
+                WEnum::Value(value) => value,
+                WEnum::Unknown(value) => panic!("invalid capture transform: {}", value),
+            };
+            Some(ShmImage {
+                fd,
+                width,
+                height,
+                transform,
+            })
         } else {
             None
         }
@@ -489,6 +498,7 @@ pub struct ShmImage<T: AsFd> {
     fd: T,
     pub width: u32,
     pub height: u32,
+    pub transform: wl_output::Transform,
 }
 
 impl<T: AsFd> ShmImage<T> {


### PR DESCRIPTION
Dealing with rotated outputs should be much better now. As well as flipped outputs (whoever uses those), and scale factors in non-interactive screenshots that combine outputs.

* Handle flipped buffer transforms
* Apply transform when showing previews in screenshot/screencast dialog
* Apply transform when combining screenshots of different outputs
* Scale down scaled outputs when combining outputs into a single screenshot
* Pass transform over pipewire, so it is handled correctly by screencast clients