### PR TITLE
fix: set M_MMAP_THRESHOLD to prevent glibc memory fragmentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,4 +86,5 @@ clap = { version = "4.5.9", features = ["derive"] }
 # sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit//", rev = "3bed072" }
 
 [profile.release]
-debug = true
+opt-level = 3
+lto = "thin"


### PR DESCRIPTION
This reduced memory consumption of the service by 200 MB on my system. Seems a handful of our apps trigger this bug in glibc's malloc implementation.

https://github.com/pop-os/cosmic-bg/pull/73