### PR TITLE
screencast: Properly accumuate buffer damage and send to compositor

### DIFF
--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -271,7 +271,10 @@ impl StreamData {
         let buffer = unsafe { stream.dequeue_raw_buffer() };
         if !buffer.is_null() {
             let wl_buffer = unsafe { &*((*buffer).user_data as *const wl_buffer::WlBuffer) };
-            match block_on(self.session.capture_wl_buffer(wl_buffer)) {
+            match block_on(
+                self.session
+                    .capture_wl_buffer(wl_buffer, self.width, self.height),
+            ) {
                 Ok(frame) => {
                     if let Some(video_transform) = unsafe {
                         buffer_find_meta_data::<spa_sys::spa_meta_videotransform>(

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -42,7 +42,7 @@ use wayland_protocols::{
     },
 };
 
-pub use cosmic_client_toolkit::screencopy::CaptureSource;
+pub use cosmic_client_toolkit::screencopy::{CaptureSource, Rect};
 
 use crate::buffer;
 
@@ -194,12 +194,19 @@ impl Session {
     pub async fn capture_wl_buffer(
         &self,
         buffer: &wl_buffer::WlBuffer,
+        width: u32,
+        height: u32,
     ) -> Result<Frame, WEnum<FailureReason>> {
         let (sender, receiver) = oneshot::channel();
         // TODO damage
         self.0.capture_session.capture(
             buffer,
-            &[],
+            &[Rect {
+                x: 0,
+                y: 0,
+                width: width as i32,
+                height: height as i32,
+            }],
             &self.0.wayland_helper.inner.qh,
             FrameData {
                 frame_data: Default::default(),
@@ -384,7 +391,7 @@ impl WaylandHelper {
         let buffer =
             self.create_shm_buffer(&fd, width, height, width * 4, wl_shm::Format::Abgr8888);
 
-        let res = session.capture_wl_buffer(&buffer).await;
+        let res = session.capture_wl_buffer(&buffer, width, height).await;
         buffer.destroy();
 
         if let Ok(frame) = res {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -194,19 +194,13 @@ impl Session {
     pub async fn capture_wl_buffer(
         &self,
         buffer: &wl_buffer::WlBuffer,
-        width: u32,
-        height: u32,
+        buffer_damage: &[Rect],
     ) -> Result<Frame, WEnum<FailureReason>> {
         let (sender, receiver) = oneshot::channel();
         // TODO damage
         self.0.capture_session.capture(
             buffer,
-            &[Rect {
-                x: 0,
-                y: 0,
-                width: width as i32,
-                height: height as i32,
-            }],
+            buffer_damage,
             &self.0.wayland_helper.inner.qh,
             FrameData {
                 frame_data: Default::default(),
@@ -391,7 +385,13 @@ impl WaylandHelper {
         let buffer =
             self.create_shm_buffer(&fd, width, height, width * 4, wl_shm::Format::Abgr8888);
 
-        let res = session.capture_wl_buffer(&buffer, width, height).await;
+        let damage = &[Rect {
+            x: 0,
+            y: 0,
+            width: width as i32,
+            height: height as i32,
+        }];
+        let res = session.capture_wl_buffer(&buffer, damage).await;
         buffer.destroy();
 
         if let Ok(frame) = res {


### PR DESCRIPTION
This fixes screen capture if `xdg-desktop-portal-cosmic` is run on Sway. (And will be needed on cosmic-comp when the compositor properly handles buffer damage for screen capture.)