### PR TITLE
Update screencast_thread.rs for support fps limit

### DIFF
--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -15,17 +15,30 @@ use pipewire::{
     stream::{StreamRef, StreamState},
     sys::pw_buffer,
 };
-use std::{collections::HashMap, ffi::c_void, io, iter, os::fd::IntoRawFd, slice};
+use spa_sys::{spa_format_video_raw_parse, spa_video_info_raw};
+
+use std::{
+    collections::HashMap,
+    ffi::c_void,
+    io, iter,
+    os::fd::IntoRawFd,
+    slice,
+    time::{Duration, Instant},
+};
 use tokio::sync::oneshot;
 use wayland_client::{
     protocol::{wl_buffer, wl_output, wl_shm},
     WEnum,
 };
+use wayland_protocols::wp::input_timestamps::zv1::client::zwp_input_timestamps_v1;
 
 use crate::{
     buffer,
     wayland::{CaptureSource, DmabufHelper, Session, WaylandHelper},
 };
+
+const TIMESPEC_NSEC_PER_SEC: u32 = 1_000_000_000;
+const FPS_MEASURE_PERIOD_SEC: u64 = 5;
 
 pub struct ScreencastThread {
     node_id: u32,
@@ -40,6 +53,7 @@ impl ScreencastThread {
     ) -> anyhow::Result<Self> {
         let (tx, rx) = oneshot::channel();
         let (thread_stop_tx, thread_stop_rx) = pipewire::channel::channel::<()>();
+
         std::thread::spawn(move || {
             match start_stream(wayland_helper, capture_source, overlay_cursor) {
                 Ok((loop_, _stream, _listener, _context, node_id_rx)) => {
@@ -53,6 +67,7 @@ impl ScreencastThread {
                 Err(err) => tx.send(Err(err)).unwrap(),
             }
         });
+
         Ok(Self {
             // XXX can second unwrap fail?
             node_id: rx.await.unwrap()?.await.unwrap()?,
@@ -68,6 +83,54 @@ impl ScreencastThread {
         let _ = self.thread_stop_tx.send(());
     }
 }
+struct FPSLimit {
+    frame_last_time: Instant,
+    fps_last_time: Instant,
+    fps_frame_count: u64,
+}
+
+impl FPSLimit {
+    fn new() -> Self {
+        Self {
+            frame_last_time: Instant::now(),
+            fps_last_time: Instant::now(),
+            fps_frame_count: 0,
+        }
+    }
+
+    fn fps_limit_measure_start(&mut self) {
+        self.frame_last_time = Instant::now();
+    }
+
+    fn measure_fps(&mut self) {
+        let now = Instant::now();
+        self.fps_frame_count += 1;
+        let elapsed_sec = (now - self.fps_last_time).as_secs();
+        if elapsed_sec < FPS_MEASURE_PERIOD_SEC {
+            return;
+        }
+
+        let avg_frames_per_sec = self.fps_frame_count / elapsed_sec;
+        println!(
+            "fps_limit: average FPS in the last {} seconds: {}",
+            avg_frames_per_sec, elapsed_sec
+        );
+        self.fps_frame_count = 0;
+        self.fps_last_time = now;
+    }
+
+    fn wait_for_next_frame(&mut self, max_fps: u32) {
+        self.measure_fps();
+
+        let elapsed_ns = self.frame_last_time.elapsed().as_nanos();
+        let target_ns = (TIMESPEC_NSEC_PER_SEC / max_fps) as u128;
+        if target_ns > elapsed_ns {
+            let delay_ns = (target_ns - elapsed_ns) as u64;
+            // println!("Time til next: {}ns", delay_ns);
+            std::thread::sleep(Duration::from_nanos(delay_ns));
+        }
+    }
+}
 
 struct StreamData {
     dmabuf_helper: Option<DmabufHelper>,
@@ -78,6 +141,11 @@ struct StreamData {
     height: u32,
     node_id_tx: Option<oneshot::Sender<Result<u32, anyhow::Error>>>,
     buffer_damage: HashMap<wl_buffer::WlBuffer, Vec<Rect>>,
+    // fps limit
+    framerate: u32,
+    seq: u32,
+    fps_limit: FPSLimit,
+    fps_max: u32,
 }
 
 impl StreamData {
@@ -146,6 +214,23 @@ impl StreamData {
         if let Some(pod) = pod {
             let value = PodDeserializer::deserialize_from::<pod::Value>(pod.as_bytes());
             if let Ok((_, pod::Value::Object(object))) = &value {
+                let pwr_format: spa_video_info_raw = unsafe {
+                    let mut pwr_format = std::mem::MaybeUninit::<spa_video_info_raw>::uninit();
+                    spa_format_video_raw_parse(
+                        pod.as_raw_ptr() as *const _,
+                        pwr_format.as_mut_ptr(),
+                    );
+                    pwr_format.assume_init()
+                };
+                if pwr_format.max_framerate.num != 0 && pwr_format.max_framerate.denom != 0 {
+                    let framerate = pwr_format.max_framerate.num / pwr_format.max_framerate.denom;
+                    self.framerate = if framerate > self.fps_max {
+                        self.fps_max
+                    } else {
+                        framerate
+                    };
+                }
+
                 if let Some(modifier_prop) = object
                     .properties
                     .iter()
@@ -177,6 +262,7 @@ impl StreamData {
                             let params = params(
                                 self.width,
                                 self.height,
+                                self.framerate,
                                 plane_count,
                                 self.dmabuf_helper.as_ref(),
                                 Some(modifier),
@@ -273,6 +359,12 @@ impl StreamData {
     fn process(&mut self, stream: &StreamRef) {
         let buffer = unsafe { stream.dequeue_raw_buffer() };
         if !buffer.is_null() {
+            // Only wait if it not the first frame
+            if self.seq > 0 {
+                // Maybe there's a better way, e.g., using an event loop to wait and get a new frame
+                self.fps_limit.wait_for_next_frame(self.framerate);
+            }
+
             let wl_buffer = unsafe { &*((*buffer).user_data as *const wl_buffer::WlBuffer) };
             let full_damage = &[Rect {
                 x: 0,
@@ -311,6 +403,8 @@ impl StreamData {
                 }
             }
             unsafe { stream.queue_raw_buffer(buffer) };
+            self.fps_limit.fps_limit_measure_start();
+            self.seq += 1;
         }
     }
 }
@@ -341,6 +435,8 @@ fn start_stream(
             None => return Err(anyhow::anyhow!("failed to use shm capture to get size")),
         };
 
+    let framerate = 60; // Default framerate. XXX is there a better way?
+
     let dmabuf_helper = wayland_helper.dmabuf();
 
     let stream = pipewire::stream::Stream::new(
@@ -352,7 +448,7 @@ fn start_stream(
         },
     )?;
 
-    let initial_params = params(width, height, 1, dmabuf_helper.as_ref(), None);
+    let initial_params = params(width, height, framerate, 1, dmabuf_helper.as_ref(), None);
     let mut initial_params: Vec<_> = initial_params
         .iter()
         .map(|x| Pod::from_bytes(x.as_slice()).unwrap())
@@ -379,6 +475,10 @@ fn start_stream(
         height,
         node_id_tx: Some(node_id_tx),
         buffer_damage: HashMap::new(),
+        framerate,
+        fps_limit: FPSLimit::new(),
+        fps_max: 120, // XXX
+        seq: 0,
     };
 
     let listener = stream
@@ -443,16 +543,17 @@ fn meta() -> Vec<u8> {
 fn params(
     width: u32,
     height: u32,
+    framerate: u32,
     blocks: u32,
     dmabuf: Option<&DmabufHelper>,
     fixated_modifier: Option<gbm::Modifier>,
 ) -> Vec<Vec<u8>> {
     [
         Some(buffers(width, height, blocks)),
-        fixated_modifier.map(|x| format(width, height, None, Some(x))),
+        fixated_modifier.map(|x| format(width, height, framerate, None, Some(x))),
         // Favor dmabuf over shm by listing it first
-        dmabuf.map(|x| format(width, height, Some(x), None)),
-        Some(format(width, height, None, None)),
+        dmabuf.map(|x| format(width, height, framerate, Some(x), None)),
+        Some(format(width, height, framerate, None, None)),
         Some(meta()),
     ]
     .into_iter()
@@ -523,6 +624,7 @@ fn buffers(width: u32, height: u32, blocks: u32) -> Vec<u8> {
 fn format(
     width: u32,
     height: u32,
+    framerate: u32,
     dmabuf: Option<&DmabufHelper>,
     fixated_modifier: Option<gbm::Modifier>,
 ) -> Vec<u8> {
@@ -550,7 +652,25 @@ fn format(
         pod::Property {
             key: spa_sys::SPA_FORMAT_VIDEO_framerate,
             flags: pod::PropertyFlags::empty(),
-            value: pod::Value::Fraction(spa::utils::Fraction { num: 60, denom: 1 }),
+            value: pod::Value::Fraction(spa::utils::Fraction { num: 0, denom: 1 }),
+        },
+        pod::Property {
+            key: spa_sys::SPA_FORMAT_VIDEO_maxFramerate,
+            flags: pod::PropertyFlags::empty(),
+            value: pod::Value::Choice(pod::ChoiceValue::Fraction(spa::utils::Choice(
+                spa::utils::ChoiceFlags::empty(),
+                spa::utils::ChoiceEnum::Range {
+                    default: spa::utils::Fraction {
+                        num: framerate,
+                        denom: 1,
+                    },
+                    min: spa::utils::Fraction { num: 1, denom: 1 },
+                    max: spa::utils::Fraction {
+                        num: framerate,
+                        denom: 1,
+                    },
+                },
+            ))),
         },
         // TODO max framerate
     ];


### PR DESCRIPTION
#149
Needs testing. I am using std::thread::sleep to block the thread until the next frame capture time. I'm not sure if it will cause any issues.