### PR TITLE
Fixes and improvements for screenshots

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
-use crate::{access, config, file_chooser, fl, screencast_dialog, screenshot, subscription};
+use crate::{access, config, file_chooser, screencast_dialog, screenshot, subscription};
 use cosmic::iced_core::event::wayland::OutputEvent;
-use cosmic::widget::{self, dropdown};
+use cosmic::widget;
 use cosmic::Task;
 use cosmic::{
     app, cosmic_config,
@@ -100,25 +100,6 @@ impl cosmic::Application for CosmicPortal {
             config,
         }: Self::Flags,
     ) -> (Self, cosmic::iced::Task<cosmic::Action<Self::Message>>) {
-        let mut model = cosmic::widget::dropdown::multi::model();
-        model.insert(dropdown::multi::list(
-            Some(fl!("save-to")),
-            vec![
-                (
-                    fl!("save-to", "clipboard"),
-                    config::screenshot::ImageSaveLocation::Clipboard,
-                ),
-                (
-                    fl!("save-to", "pictures"),
-                    config::screenshot::ImageSaveLocation::Pictures,
-                ),
-                (
-                    fl!("save-to", "documents"),
-                    config::screenshot::ImageSaveLocation::Documents,
-                ),
-            ],
-        ));
-        model.selected = Some(config.screenshot.save_location);
         let wayland_conn = crate::wayland::connect_to_wayland();
         let wayland_helper = crate::wayland::WaylandHelper::new(wayland_conn);
         (

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -300,15 +300,17 @@ fn combined_image(bounds: Rect, frames: impl Iterator<Item = (RgbaImage, Rect)>)
         .try_into()
         .unwrap_or_default();
     let mut image = image::RgbaImage::new(width, height);
-    for (frame_image, rect) in frames {
+    for (mut frame_image, rect) in frames {
         let width = (rect.right - rect.left) as u32;
         let height = (rect.bottom - rect.top) as u32;
-        let frame_image = image::imageops::resize(
-            &frame_image,
-            width,
-            height,
-            image::imageops::FilterType::Lanczos3,
-        );
+        if frame_image.dimensions() != (width, height) {
+            frame_image = image::imageops::resize(
+                &frame_image,
+                width,
+                height,
+                image::imageops::FilterType::Lanczos3,
+            );
+        };
         let x = i64::from(rect.left) - i64::from(bounds.left);
         let y = i64::from(rect.top) - i64::from(bounds.top);
         image::imageops::overlay(&mut image, &frame_image, x, y);

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -581,7 +581,7 @@ pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<Msg
     KeyboardWrapper::new(
         crate::widget::screenshot::ScreenshotSelection::new(
             args.choice.clone(),
-            img.handle.clone(),
+            &img,
             Msg::Capture,
             Msg::Cancel,
             output,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -5,7 +5,6 @@ use cosmic::cosmic_config::CosmicConfigEntry;
 use cosmic::iced::clipboard::mime::AsMimeTypes;
 use cosmic::iced::keyboard::{key::Named, Key};
 use cosmic::iced::{window, Limits};
-use cosmic::iced_core::image::Bytes;
 use cosmic::iced_core::Length;
 use cosmic::iced_runtime::clipboard;
 use cosmic::iced_runtime::platform_specific::wayland::layer_surface::{
@@ -139,7 +138,7 @@ impl Screenshot {
     async fn interactive_toplevel_images(
         &self,
         outputs: &[Output],
-    ) -> anyhow::Result<HashMap<String, Vec<(u32, u32, Bytes)>>> {
+    ) -> anyhow::Result<HashMap<String, Vec<RgbaImage>>> {
         let wayland_helper = self.wayland_helper.clone();
         Ok(outputs
             .iter()
@@ -149,7 +148,6 @@ impl Screenshot {
                     let frame = wayland_helper
                         .capture_output_toplevels_shm(&output, false)
                         .filter_map(|img| async move { img.image_transformed().ok() })
-                        .map(|img| (img.width(), img.height(), img.into_vec().into()))
                         .collect()
                         .await;
                     (name.clone(), frame)
@@ -164,7 +162,7 @@ impl Screenshot {
         &self,
         outputs: &[Output],
         app_id: &str,
-    ) -> anyhow::Result<HashMap<String, (u32, u32, Bytes)>> {
+    ) -> anyhow::Result<HashMap<String, RgbaImage>> {
         // collect screenshots from each output
 
         let wayland_helper = self.wayland_helper.clone();
@@ -181,12 +179,7 @@ impl Screenshot {
                 .capture_source_shm(CaptureSource::Output(output.clone()), false)
                 .await
                 .ok_or_else(|| anyhow::anyhow!("shm screencopy failed"))?;
-            map.insert(
-                name.clone(),
-                frame
-                    .image_transformed()
-                    .map(|img| (img.width(), img.height(), img.into_vec().into()))?,
-            );
+            map.insert(name.clone(), frame.image_transformed()?);
         }
 
         Ok(map)
@@ -389,8 +382,8 @@ pub struct Args {
     pub app_id: String,
     pub parent_window: String,
     pub options: ScreenshotOptions,
-    pub output_images: HashMap<String, (u32, u32, Bytes)>,
-    pub toplevel_images: HashMap<String, Vec<(u32, u32, Bytes)>>,
+    pub output_images: HashMap<String, RgbaImage>,
+    pub toplevel_images: HashMap<String, Vec<RgbaImage>>,
     pub tx: Sender<PortalResponse<ScreenshotResult>>,
     pub choice: Choice,
     pub location: ImageSaveLocation,
@@ -555,14 +548,18 @@ pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<Msg
         return horizontal_space().width(Length::Fixed(1.0)).into();
     };
 
-    let Some((width, height, pixels)) = args.output_images.get(&output.name).cloned() else {
+    let Some(img) = args.output_images.get(&output.name) else {
         return horizontal_space().width(Length::Fixed(1.0)).into();
     };
     let theme = portal.core.system_theme().cosmic();
     KeyboardWrapper::new(
         crate::widget::screenshot::ScreenshotSelection::new(
             args.choice.clone(),
-            cosmic::widget::image::Handle::from_rgba(width, height, pixels),
+            cosmic::widget::image::Handle::from_rgba(
+                img.width(),
+                img.height(),
+                img.as_raw().clone(),
+            ),
             Msg::Capture,
             Msg::Cancel,
             output,
@@ -612,29 +609,19 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
 
             match choice {
                 Choice::Output(name) => {
-                    if let Some((width, height, buf)) = images.remove(&name) {
+                    if let Some(img) = images.remove(&name) {
                         if let Some(ref image_path) = image_path {
-                            if let Some(img) = RgbaImage::from_raw(width, height, buf.into()) {
-                                if let Err(err) = Screenshot::save_rgba(&img, image_path) {
-                                    log::error!("Failed to capture screenshot: {:?}", err);
-                                };
-                            } else {
-                                log::error!("Failed to produce rgba image for screenshot");
-                                success = false;
-                            }
+                            if let Err(err) = Screenshot::save_rgba(&img, image_path) {
+                                log::error!("Failed to capture screenshot: {:?}", err);
+                            };
                         } else {
-                            if let Some(img) = RgbaImage::from_raw(width, height, buf.into()) {
-                                let mut buffer = Vec::new();
-                                if let Err(e) = Screenshot::save_rgba_to_buffer(&img, &mut buffer) {
-                                    log::error!("Failed to save screenshot to buffer: {:?}", e);
-                                    success = false;
-                                } else {
-                                    cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)))
-                                };
-                            } else {
-                                log::error!("Failed to produce rgba image for screenshot");
+                            let mut buffer = Vec::new();
+                            if let Err(e) = Screenshot::save_rgba_to_buffer(&img, &mut buffer) {
+                                log::error!("Failed to save screenshot to buffer: {:?}", e);
                                 success = false;
-                            }
+                            } else {
+                                cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)))
+                            };
                         }
                     } else {
                         log::error!("Failed to find output {}", name);
@@ -663,7 +650,7 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
                                 continue;
                             };
                             let mut translated_intersect = intersect.translate(-pos.0, -pos.1);
-                            let scale = raw_img.0 as f32 / output.logical_size.0 as f32;
+                            let scale = raw_img.width() as f32 / output.logical_size.0 as f32;
                             translated_intersect.left =
                                 (translated_intersect.left as f32 * scale).round() as i32;
                             translated_intersect.top =
@@ -672,11 +659,6 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
                                 (translated_intersect.right as f32 * scale).round() as i32;
                             translated_intersect.bottom =
                                 (translated_intersect.bottom as f32 * scale).round() as i32;
-                            let Some(raw_img) =
-                                RgbaImage::from_raw(raw_img.0, raw_img.1, raw_img.2.to_vec())
-                            else {
-                                continue;
-                            };
                             let overlay = image::imageops::crop_imm(
                                 &raw_img,
                                 u32::try_from(translated_intersect.left).unwrap_or_default(),
@@ -728,34 +710,24 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
                     }
                 }
                 Choice::Window(output, Some(window_i)) => {
-                    if let Some((width, height, buf)) = args
+                    if let Some(img) = args
                         .toplevel_images
                         .get(&output)
                         .and_then(|imgs| imgs.get(window_i))
                     {
                         if let Some(ref image_path) = image_path {
-                            if let Some(img) = RgbaImage::from_raw(*width, *height, buf.to_vec()) {
-                                if let Err(err) = Screenshot::save_rgba(&img, image_path) {
-                                    log::error!("Failed to capture screenshot: {:?}", err);
-                                    success = false;
-                                }
-                            } else {
-                                log::error!("Failed to produce rgba image for screenshot");
+                            if let Err(err) = Screenshot::save_rgba(&img, image_path) {
+                                log::error!("Failed to capture screenshot: {:?}", err);
                                 success = false;
                             }
                         } else {
                             let mut buffer = Vec::new();
-                            if let Some(img) = RgbaImage::from_raw(*width, *height, buf.to_vec()) {
-                                if let Err(e) = Screenshot::save_rgba_to_buffer(&img, &mut buffer) {
-                                    log::error!("Failed to save screenshot to buffer: {:?}", e);
-                                    success = false;
-                                } else {
-                                    cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)))
-                                };
-                            } else {
-                                log::error!("Failed to produce rgba image for screenshot");
+                            if let Err(e) = Screenshot::save_rgba_to_buffer(&img, &mut buffer) {
+                                log::error!("Failed to save screenshot to buffer: {:?}", e);
                                 success = false;
-                            }
+                            } else {
+                                cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)))
+                            };
                         }
                     } else {
                         success = false;

--- a/src/widget/rectangle_selection.rs
+++ b/src/widget/rectangle_selection.rs
@@ -382,7 +382,7 @@ impl<Msg: 'static + Clone> Widget<Msg, cosmic::Theme, cosmic::Renderer>
                             return cosmic::iced_core::event::Status::Ignored;
                         }
 
-                        self.handle_drag_pos(x as i32, y as i32, shell);
+                        self.handle_drag_pos(x.round() as i32, y.round() as i32, shell);
                         cosmic::iced_core::event::Status::Captured
                     }
                     OfferEvent::Motion { x, y } => {
@@ -391,7 +391,7 @@ impl<Msg: 'static + Clone> Widget<Msg, cosmic::Theme, cosmic::Renderer>
                         if !cursor.is_over(layout.bounds()) {
                             return cosmic::iced_core::event::Status::Ignored;
                         }
-                        self.handle_drag_pos(x as i32, y as i32, shell);
+                        self.handle_drag_pos(x.round() as i32, y.round() as i32, shell);
                         cosmic::iced_core::event::Status::Captured
                     }
                     OfferEvent::Drop => {

--- a/src/widget/rectangle_selection.rs
+++ b/src/widget/rectangle_selection.rs
@@ -80,11 +80,11 @@ const EDGE_GRAB_THICKNESS: f32 = 8.0;
 const CORNER_DIAMETER: f32 = 16.0;
 
 pub struct RectangleSelection<Msg> {
-    pub output_rect: Rect,
-    pub rectangle_selection: Rect,
-    pub window_id: iced_core::window::Id,
-    pub on_rectangle: Box<dyn Fn(DragState, Rect) -> Msg>,
-    pub drag_state: DragState,
+    output_rect: Rect,
+    rectangle_selection: Rect,
+    window_id: iced_core::window::Id,
+    on_rectangle: Box<dyn Fn(DragState, Rect) -> Msg>,
+    drag_state: DragState,
     widget_id: widget::Id,
     drag_id: u128,
 }

--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -65,7 +65,7 @@ where
 {
     pub fn new(
         choice: Choice,
-        image_handle: image::Handle,
+        image: &ScreenshotImage,
         on_capture: Msg,
         on_cancel: Msg,
         output: &OutputState,
@@ -146,7 +146,7 @@ where
         };
 
         let bg_element = match choice {
-            Choice::Output(_) | Choice::Rectangle(..) => image::Image::new(image_handle)
+            Choice::Output(_) | Choice::Rectangle(..) => image::Image::new(image.handle.clone())
                 .width(Length::Fill)
                 .height(Length::Fill)
                 .into(),

--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, collections::HashMap, rc::Rc, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, rc::Rc};
 
-use ::image::{EncodableLayout, RgbaImage};
+use ::image::RgbaImage;
 use cosmic::{
     cosmic_theme::Spacing,
     iced::{self, window},
@@ -59,14 +59,6 @@ pub struct ScreenshotSelection<'a, Msg> {
 //  - menu
 
 // for now lets just support selecting the output
-
-pub struct MyImage(pub Arc<RgbaImage>);
-
-impl AsRef<[u8]> for MyImage {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
 
 impl<'a, Msg> ScreenshotSelection<'a, Msg>
 where

--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, collections::HashMap, rc::Rc};
 
-use ::image::RgbaImage;
 use cosmic::{
     cosmic_theme::Spacing,
     iced::{self, window},
@@ -21,7 +20,7 @@ use wayland_client::protocol::wl_output::WlOutput;
 use crate::{
     app::OutputState,
     fl,
-    screenshot::{Choice, Rect},
+    screenshot::{Choice, Rect, ScreenshotImage},
 };
 
 use super::{
@@ -73,7 +72,7 @@ where
         window_id: window::Id,
         on_output_change: impl Fn(WlOutput) -> Msg,
         on_choice_change: impl Fn(Choice) -> Msg + 'static + Clone,
-        toplevel_images: &HashMap<String, Vec<RgbaImage>>,
+        toplevel_images: &HashMap<String, Vec<ScreenshotImage>>,
         toplevel_chosen: impl Fn(String, usize) -> Msg,
         save_locations: &'a Vec<String>,
         selected_save_location: usize,
@@ -120,12 +119,8 @@ where
                         (img.width() as u64 * u16::MAX as u64 / total_img_width as u64).max(1);
                     layer_container(
                         button::custom(
-                            image::Image::new(image::Handle::from_rgba(
-                                img.width(),
-                                img.height(),
-                                img.as_raw().clone(),
-                            ))
-                            .content_fit(ContentFit::ScaleDown),
+                            image::Image::new(img.handle.clone())
+                                .content_fit(ContentFit::ScaleDown),
                         )
                         .on_press(toplevel_chosen(output.name.clone(), i))
                         .class(cosmic::theme::Button::Image),

--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -5,8 +5,8 @@ use cosmic::{
     cosmic_theme::Spacing,
     iced::{self, window},
     iced_core::{
-        alignment, gradient::Linear, image::Bytes, layout, overlay, widget::Tree, Background,
-        Border, ContentFit, Degrees, Layout, Length, Point, Size,
+        alignment, gradient::Linear, layout, overlay, widget::Tree, Background, Border, ContentFit,
+        Degrees, Layout, Length, Point, Size,
     },
     iced_widget::row,
     widget::{
@@ -81,7 +81,7 @@ where
         window_id: window::Id,
         on_output_change: impl Fn(WlOutput) -> Msg,
         on_choice_change: impl Fn(Choice) -> Msg + 'static + Clone,
-        toplevel_images: &HashMap<String, Vec<(u32, u32, Bytes)>>,
+        toplevel_images: &HashMap<String, Vec<RgbaImage>>,
         toplevel_chosen: impl Fn(String, usize) -> Msg,
         save_locations: &'a Vec<String>,
         selected_save_location: usize,
@@ -119,16 +119,21 @@ where
             Choice::Window(..) => {
                 let imgs = toplevel_images
                     .get(&output.name)
-                    .cloned()
+                    .map(|x| x.as_slice())
                     .unwrap_or_default();
-                let total_img_width = imgs.iter().map(|img| img.0).sum::<u32>();
+                let total_img_width = imgs.iter().map(|img| img.width()).sum::<u32>();
 
                 let img_buttons = imgs.into_iter().enumerate().map(|(i, img)| {
-                    let portion = (img.0 as u64 * u16::MAX as u64 / total_img_width as u64).max(1);
+                    let portion =
+                        (img.width() as u64 * u16::MAX as u64 / total_img_width as u64).max(1);
                     layer_container(
                         button::custom(
-                            image::Image::new(image::Handle::from_rgba(img.0, img.1, img.2))
-                                .content_fit(ContentFit::ScaleDown),
+                            image::Image::new(image::Handle::from_rgba(
+                                img.width(),
+                                img.height(),
+                                img.as_raw().clone(),
+                            ))
+                            .content_fit(ContentFit::ScaleDown),
                         )
                         .on_press(toplevel_chosen(output.name.clone(), i))
                         .class(cosmic::theme::Button::Image),


### PR DESCRIPTION
Fixes rounding error in rectangle selection, use subsurfaces (https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/113), avoid image copy/transform until needed.

To fix https://github.com/pop-os/cosmic-screenshot/issues/87, this should also share the code used for non-interactive screenshots with rectangle selection.