### PR TITLE
bugfix(screencast): add desktop entry icons to toplevel buttons

### DIFF
--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -59,8 +59,8 @@ pub async fn show_screencast_prompt(
         .toplevels()
         .into_iter()
         .map(|info| {
-            let icon = get_desktop_entry(&desktop_entries, &app_id)
-                .and_then(|x| Some(x.name(&locales)?.into_owned()));
+            let icon = get_desktop_entry(&desktop_entries, &info.app_id)
+                .and_then(|x| Some(x.icon()?.to_string()));
             (info, icon)
         })
         .collect();


### PR DESCRIPTION
**changes tl;dr**
- when trying to screencast a specific toplevel, all icons display the fallback
- this pulls in the correct icons for each toplevel

![image](https://github.com/user-attachments/assets/9675b272-9d35-4283-877d-dd9aa8f8ab13)
