### PR TITLE
screencast/pipewire: Don't allow implict modifiers, and fallback to shm if modifier isn't negotiated

### DIFF
--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -227,6 +227,15 @@ impl StreamData {
                                 log::error!("failed to update pipewire params: {}", err);
                             }
                             return;
+                        } else {
+                            log::error!("failed to choose modifier from {:?}", modifiers);
+                            let params =
+                                format_params(self.width, self.height, None, None, &self.formats);
+                            let mut params: Vec<_> = params.iter().map(|x| &**x).collect();
+                            if let Err(err) = stream.update_params(&mut params) {
+                                log::error!("failed to update pipewire params: {}", err);
+                            }
+                            return;
                         }
                     }
                 }

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -94,7 +94,7 @@ impl StreamData {
     }
 
     // Get driver preferred modifier, and plane count
-    fn choose_modifier(&self, modifiers: &[gbm::Modifier]) -> Option<(gbm::Modifier, u32)> {
+    fn choose_modifier(&self, modifiers: &[gbm::Modifier]) -> Option<gbm::Modifier> {
         let dmabuf_helper = self.dmabuf_helper.as_ref().unwrap();
         let mut gbm_devices = dmabuf_helper.gbm_devices().lock().unwrap();
         let dev = self
@@ -119,7 +119,7 @@ impl StreamData {
                 gbm::Format::Abgr8888,
                 gbm::BufferObjectFlags::empty(),
             ) {
-                Ok(bo) => Some((gbm::Modifier::Invalid, bo.plane_count())),
+                Ok(bo) => Some(gbm::Modifier::Invalid),
                 Err(err) => {
                     log::error!(
                         "Failed to choose modifier by creating temporary bo: {}",
@@ -136,7 +136,7 @@ impl StreamData {
                 modifiers.iter().copied(),
                 gbm::BufferObjectFlags::empty(),
             ) {
-                Ok(bo) => Some((bo.modifier(), bo.plane_count())),
+                Ok(bo) => Some(bo.modifier()),
                 Err(err) => {
                     log::error!(
                         "Failed to choose modifier by creating temporary bo: {}",
@@ -212,7 +212,7 @@ impl StreamData {
                             .chain(alternatives)
                             .map(|x| gbm::Modifier::from(*x as u64))
                             .collect::<Vec<_>>();
-                        if let Some((modifier, plane_count)) = self.choose_modifier(&modifiers) {
+                        if let Some(modifier) = self.choose_modifier(&modifiers) {
                             self.modifier = modifier;
 
                             let params = format_params(


### PR DESCRIPTION
I seems to have gotten this working, after some testing and looking at the code in mutter and xdg-desktop-portal-wlr. (Pipewire's documentation isn't always that great.) I still need to clean up the implementation here.

This fixes capture of Nvidia outputs to an instance of OBS running on an Intel GPU, at the cost of falling back to shm capture.  Not sure if there's a good way to make sure this ends up doing more efficient GPU-to-GPU copies without relying on shm, but we'll want the fixes for shm fallback anyway, and we want to avoid implict modifiers in multi-GPU systems.