### PR TITLE
screencast: Support metadata cursor capture

### DIFF
--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::Sender;
 use zbus::zvariant;
 
 use crate::screencast_dialog::{self, CaptureSources};
-use crate::screencast_thread::ScreencastThread;
+use crate::screencast_thread::{CursorMode, ScreencastThread};
 use crate::wayland::{CaptureSource, WaylandHelper};
 use crate::{PortalResponse, Request, subscription};
 
@@ -146,7 +146,7 @@ struct StartResult {
 #[derive(Default)]
 struct SessionData {
     screencast_threads: Vec<ScreencastThread>,
-    cursor_mode: Option<u32>,
+    cursor_mode: Option<CursorMode>,
     multiple: bool,
     source_types: BitFlags<SourceType>,
     persisted_capture_sources: Option<PersistedCaptureSources>,
@@ -210,7 +210,16 @@ impl ScreenCast {
         match crate::session_interface::<SessionData>(connection, &session_handle).await {
             Some(interface) => {
                 let mut session_data = interface.get_mut().await;
-                session_data.cursor_mode = options.cursor_mode;
+                session_data.cursor_mode = match options.cursor_mode {
+                    Some(CURSOR_MODE_HIDDEN) => Some(CursorMode::Hidden),
+                    Some(CURSOR_MODE_EMBEDDED) => Some(CursorMode::Embedded),
+                    Some(CURSOR_MODE_METADATA) => Some(CursorMode::Metadata),
+                    Some(value) => {
+                        log::error!("unrecognized screencopy cursor mode: {}", value);
+                        None
+                    }
+                    None => None,
+                };
                 session_data.multiple = options.multiple.unwrap_or(false);
                 session_data.source_types =
                     BitFlags::from_bits_truncate(options.types.unwrap_or(0));
@@ -249,7 +258,7 @@ impl ScreenCast {
 
             let (cursor_mode, multiple, source_types, persisted_capture_sources) = {
                 let session_data = interface.get_mut().await;
-                let cursor_mode = session_data.cursor_mode.unwrap_or(CURSOR_MODE_EMBEDDED);
+                let cursor_mode = session_data.cursor_mode.unwrap_or(CursorMode::Embedded);
                 let multiple = session_data.multiple;
                 let source_types = session_data.source_types;
                 let persisted_capture_sources = session_data.persisted_capture_sources.clone();
@@ -289,7 +298,6 @@ impl ScreenCast {
                 capture_sources
             };
 
-            let overlay_cursor = cursor_mode == CURSOR_MODE_EMBEDDED;
             // Use `FuturesOrdered` so streams are in consistent order
             let mut res_futures = FuturesOrdered::new();
             for output in &capture_sources.outputs {
@@ -302,7 +310,7 @@ impl ScreenCast {
                 res_futures.push_back(ScreencastThread::new(
                     self.wayland_helper.clone(),
                     CaptureSource::Output(output.clone()),
-                    overlay_cursor,
+                    cursor_mode,
                     StreamProps {
                         position,
                         size,
@@ -329,7 +337,7 @@ impl ScreenCast {
                 res_futures.push_back(ScreencastThread::new(
                     self.wayland_helper.clone(),
                     CaptureSource::Toplevel(foreign_toplevel.clone()),
-                    overlay_cursor,
+                    cursor_mode,
                     StreamProps {
                         position: None,
                         size,

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -348,7 +348,7 @@ impl ScreenCast {
             }
 
             let mut failed = false;
-            let mut screencast_threads = Vec::new();
+            let mut screencast_threads = Vec::<ScreencastThread>::new();
             while let Some(res) = res_futures.next().await {
                 match res {
                     Ok(thread) => screencast_threads.push(thread),
@@ -402,8 +402,7 @@ impl ScreenCast {
 
     #[zbus(property)]
     async fn available_cursor_modes(&self) -> u32 {
-        // TODO: Support metadata?
-        CURSOR_MODE_HIDDEN | CURSOR_MODE_EMBEDDED
+        CURSOR_MODE_HIDDEN | CURSOR_MODE_EMBEDDED | CURSOR_MODE_METADATA
     }
 
     #[zbus(property, name = "version")]

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -25,6 +25,13 @@ use crate::buffer;
 use crate::screencast::StreamProps;
 use crate::wayland::{CaptureSource, DmabufHelper, Session, WaylandHelper};
 
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum CursorMode {
+    Hidden,
+    Embedded,
+    Metadata,
+}
+
 static FORMAT_MAP: &[(gbm::Format, Id)] = &[
     (gbm::Format::Abgr8888, Id(spa_sys::SPA_VIDEO_FORMAT_RGBA)),
     (gbm::Format::Argb8888, Id(spa_sys::SPA_VIDEO_FORMAT_BGRA)),
@@ -64,7 +71,7 @@ impl ScreencastThread {
     pub async fn new(
         wayland_helper: WaylandHelper,
         capture_source: CaptureSource,
-        overlay_cursor: bool,
+        cursor_mode: CursorMode,
         stream_props: StreamProps,
     ) -> anyhow::Result<Self> {
         let (tx, rx) = oneshot::channel();
@@ -74,7 +81,7 @@ impl ScreencastThread {
             match start_stream(
                 wayland_helper,
                 capture_source,
-                overlay_cursor,
+                cursor_mode,
                 thread_stop_tx_clone,
             ) {
                 Ok((loop_, _stream, _listener, _context, node_id_rx)) => {
@@ -491,7 +498,7 @@ impl StreamData {
 fn start_stream(
     wayland_helper: WaylandHelper,
     capture_source: CaptureSource,
-    overlay_cursor: bool,
+    cursor_mode: CursorMode,
     thread_stop_tx: pipewire::channel::Sender<()>,
 ) -> anyhow::Result<(
     pipewire::main_loop::MainLoopRc,
@@ -508,7 +515,8 @@ fn start_stream(
 
     let (node_id_tx, node_id_rx) = oneshot::channel();
 
-    let session = wayland_helper.capture_source_session(capture_source, overlay_cursor);
+    let session =
+        wayland_helper.capture_source_session(capture_source, cursor_mode == CursorMode::Embedded);
 
     let Some(formats) = block_on(session.wait_for_formats(|formats| formats.clone())) else {
         return Err(anyhow::anyhow!(

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -513,7 +513,7 @@ fn start_stream(
     let context = pipewire::context::ContextRc::new(&loop_, None)?;
     let core = context.connect_rc(None)?;
 
-    let name = "cosmic-screenshot".to_string(); // XXX randomize?
+    let name = "cosmic-screencast";
 
     let (node_id_tx, node_id_rx) = oneshot::channel();
 
@@ -530,10 +530,10 @@ fn start_stream(
 
     let stream = pipewire::stream::StreamRc::new(
         core,
-        &name,
+        name,
         pipewire::properties::properties! {
             "media.class" => "Video/Source",
-            "node.name" => "cosmic-screenshot", // XXX
+            "node.name" => name.to_string(),
         },
     )?;
 

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -6,6 +6,8 @@
 
 use cosmic_client_toolkit::screencopy::{FailureReason, Formats, Rect};
 use futures::executor::block_on;
+use futures::stream::StreamExt;
+use image::{GenericImage, GenericImageView};
 use pipewire::spa::pod::deserialize::PodDeserializer;
 use pipewire::spa::pod::serialize::PodSerializer;
 use pipewire::spa::pod::{self, Pod};
@@ -16,6 +18,7 @@ use pipewire::sys::pw_buffer;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::os::fd::IntoRawFd;
+use std::task::{Context, Poll, Waker};
 use std::{io, iter, slice};
 use tokio::sync::oneshot;
 use wayland_client::WEnum;
@@ -23,7 +26,12 @@ use wayland_client::protocol::{wl_buffer, wl_output, wl_shm};
 
 use crate::buffer;
 use crate::screencast::StreamProps;
-use crate::wayland::{CaptureSource, DmabufHelper, Session, WaylandHelper};
+use crate::wayland::{
+    CaptureSource, CursorFrame, CursorSession, CursorStream, DmabufHelper, Session, WaylandHelper,
+};
+
+// TODO: Update params dynamically to support different sizes of cursor
+const CURSOR_SIZE: u32 = 64;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum CursorMode {
@@ -58,6 +66,74 @@ fn shm_format_to_gbm(format: wl_shm::Format) -> Option<gbm::Format> {
         wl_shm::Format::Argb8888 => Some(gbm::Format::Argb8888),
         wl_shm::Format::Xrgb8888 => Some(gbm::Format::Xrgb8888),
         _ => gbm::Format::try_from(format as u32).ok(),
+    }
+}
+
+#[repr(C)]
+struct MetadataCursor {
+    meta_cursor: spa_sys::spa_meta_cursor,
+    meta_bitmap: spa_sys::spa_meta_bitmap,
+    bytes: [u8],
+}
+
+impl MetadataCursor {
+    pub fn size_of(width: u32, height: u32) -> usize {
+        std::mem::offset_of!(Self, meta_bitmap)
+            + std::mem::size_of::<spa_sys::spa_meta_bitmap>()
+            + width as usize * height as usize * 4
+    }
+
+    fn clear(&mut self) {
+        self.meta_cursor = spa_sys::spa_meta_cursor {
+            id: 0,
+            flags: 0,
+            position: spa_sys::spa_point { x: 0, y: 0 },
+            hotspot: spa_sys::spa_point { x: 0, y: 0 },
+            bitmap_offset: 0,
+        };
+    }
+
+    fn update(&mut self, cursor_frame: Option<&CursorFrame>, position: (i32, i32)) {
+        let (image, hotspot) = if let Some(CursorFrame { image, hotspot }) = cursor_frame {
+            (Some(image), *hotspot)
+        } else {
+            (None, (0, 0))
+        };
+        self.meta_cursor = spa_sys::spa_meta_cursor {
+            id: 1,
+            flags: 0,
+            position: spa_sys::spa_point {
+                x: position.0,
+                y: position.1,
+            },
+            hotspot: spa_sys::spa_point {
+                x: hotspot.0,
+                y: hotspot.1,
+            },
+            bitmap_offset: std::mem::offset_of!(Self, meta_bitmap) as u32,
+        };
+        let Some(image) = image else {
+            self.meta_cursor.bitmap_offset = 0;
+            return;
+        };
+        let image = image::imageops::crop_imm(image, 0, 0, CURSOR_SIZE, CURSOR_SIZE);
+        self.meta_bitmap = spa_sys::spa_meta_bitmap {
+            format: spa_sys::SPA_VIDEO_FORMAT_RGBA,
+            size: spa_sys::spa_rectangle {
+                width: image.width(),
+                height: image.height(),
+            },
+            stride: image.width() as i32 * 4,
+            offset: std::mem::size_of::<spa_sys::spa_meta_bitmap>() as u32,
+        };
+        image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(
+            image.width(),
+            image.height(),
+            &mut self.bytes,
+        )
+        .unwrap()
+        .copy_from(&*image, 0, 0)
+        .unwrap();
     }
 }
 
@@ -122,6 +198,8 @@ struct StreamData {
     format: gbm::Format,
     modifier: Option<gbm::Modifier>,
     session: Session,
+    cursor_session: Option<(CursorSession, CursorStream)>,
+    cursor_frame: Option<CursorFrame>,
     formats: Formats,
     node_id_tx: Option<oneshot::Sender<Result<u32, anyhow::Error>>>,
     buffer_damage: HashMap<wl_buffer::WlBuffer, Vec<Rect>>,
@@ -343,7 +421,13 @@ impl StreamData {
             .modifier
             .and_then(|m| self.plane_count(self.format, m))
             .unwrap_or(1);
-        let params = other_params(self.width(), self.height(), blocks, self.modifier.is_some());
+        let params = other_params(
+            self.width(),
+            self.height(),
+            blocks,
+            self.modifier.is_some(),
+            self.cursor_session.is_some(),
+        );
         let mut params: Vec<_> = params.iter().map(|x| &**x).collect();
         if let Err(err) = stream.update_params(&mut params) {
             tracing::error!("failed to update pipewire params: {}", err);
@@ -443,6 +527,14 @@ impl StreamData {
             // TODO: Causes segfault
             // let _ = stream.disconnect();
         }
+
+        if let Some((_, stream)) = &mut self.cursor_session {
+            let mut context = Context::from_waker(Waker::noop());
+            if let Poll::Ready(frame) = stream.poll_next_unpin(&mut context) {
+                self.cursor_frame = frame;
+            }
+        }
+
         let buffer = unsafe { stream.dequeue_raw_buffer() };
         if !buffer.is_null() {
             let wl_buffer = unsafe { &*((*buffer).user_data as *const wl_buffer::WlBuffer) };
@@ -475,6 +567,22 @@ impl StreamData {
                         )
                     } {
                         video_transform.transform = convert_transform(frame.transform);
+                    }
+                    if let Some((cursor_session, _)) = &self.cursor_session
+                        && let Some(cursor) = unsafe {
+                            buffer_cursor_find_meta_data(
+                                buffer,
+                                spa_sys::SPA_META_Cursor,
+                                MetadataCursor::size_of(CURSOR_SIZE, CURSOR_SIZE),
+                            )
+                        }
+                    {
+                        if cursor_session.cursor_entered() {
+                            let position = cursor_session.cursor_position();
+                            cursor.update(self.cursor_frame.as_ref(), position);
+                        } else {
+                            cursor.clear();
+                        }
                     }
                 }
                 Err(err) => {
@@ -517,8 +625,20 @@ fn start_stream(
 
     let (node_id_tx, node_id_rx) = oneshot::channel();
 
-    let session =
-        wayland_helper.capture_source_session(capture_source, cursor_mode == CursorMode::Embedded);
+    let session = wayland_helper
+        .capture_source_session(capture_source.clone(), cursor_mode == CursorMode::Embedded);
+    let mut cursor_session = None;
+    let mut cursor_frame = None;
+    if cursor_mode == CursorMode::Metadata {
+        cursor_session = wayland_helper.capture_source_cursor_session(capture_source);
+        if let Some((_session, stream)) = &mut cursor_session {
+            // Initial poll of stream to start capture
+            let mut context = Context::from_waker(Waker::noop());
+            if let Poll::Ready(frame) = stream.poll_next_unpin(&mut context) {
+                cursor_frame = frame;
+            }
+        }
+    }
 
     let Some(formats) = block_on(session.wait_for_formats(|formats| formats.clone())) else {
         return Err(anyhow::anyhow!(
@@ -553,6 +673,8 @@ fn start_stream(
         wayland_helper,
         dmabuf_helper,
         session,
+        cursor_frame,
+        cursor_session,
         formats,
         format: gbm::Format::Abgr8888,
         modifier: None,
@@ -588,6 +710,18 @@ fn convert_transform(transform: WEnum<wl_output::Transform>) -> u32 {
             spa_sys::SPA_META_TRANSFORMATION_Flipped270
         }
         WEnum::Value(_) | WEnum::Unknown(_) => unreachable!(),
+    }
+}
+
+// SAFETY: buffer must be non-null, valid as long as return value is used
+unsafe fn buffer_cursor_find_meta_data<'a>(
+    buffer: *const pipewire_sys::pw_buffer,
+    type_: u32,
+    size: usize,
+) -> Option<&'a mut MetadataCursor> {
+    unsafe {
+        let ptr = spa_sys::spa_buffer_find_meta_data((*buffer).buffer, type_, size);
+        (std::ptr::slice_from_raw_parts(ptr, size) as *mut MetadataCursor).as_mut()
     }
 }
 
@@ -647,6 +781,25 @@ fn meta() -> OwnedPod {
     // TODO: header, video damage
 }
 
+fn meta_cursor() -> OwnedPod {
+    OwnedPod::serialize(&pod::Value::Object(pod::Object {
+        type_: spa_sys::SPA_TYPE_OBJECT_ParamMeta,
+        id: spa_sys::SPA_PARAM_Meta,
+        properties: vec![
+            pod::Property {
+                key: spa_sys::SPA_PARAM_META_type,
+                flags: pod::PropertyFlags::empty(),
+                value: pod::Value::Id(spa::utils::Id(spa_sys::SPA_META_Cursor)),
+            },
+            pod::Property {
+                key: spa_sys::SPA_PARAM_META_size,
+                flags: pod::PropertyFlags::empty(),
+                value: pod::Value::Int(MetadataCursor::size_of(CURSOR_SIZE, CURSOR_SIZE) as _),
+            },
+        ],
+    }))
+}
+
 fn format_params(
     dmabuf: Option<&DmabufHelper>,
     fixated: Option<(gbm::Format, gbm::Modifier)>,
@@ -688,10 +841,17 @@ fn format_params(
     pods
 }
 
-fn other_params(width: u32, height: u32, blocks: u32, allow_dmabuf: bool) -> Vec<OwnedPod> {
+fn other_params(
+    width: u32,
+    height: u32,
+    blocks: u32,
+    allow_dmabuf: bool,
+    cursor_metadata: bool,
+) -> Vec<OwnedPod> {
     [
         Some(buffers(width, height, blocks, allow_dmabuf)),
         Some(meta()),
+        cursor_metadata.then_some(meta_cursor()),
     ]
     .into_iter()
     .flatten()

--- a/src/wayland/cursor_stream.rs
+++ b/src/wayland/cursor_stream.rs
@@ -1,0 +1,189 @@
+use cosmic_client_toolkit::screencopy::{CaptureSession, FailureReason, Frame, Rect};
+use futures::channel::oneshot;
+use std::future::Future;
+use std::os::fd::OwnedFd;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, Weak};
+use std::task::{Context, Poll};
+use wayland_client::WEnum;
+use wayland_client::protocol::{wl_buffer, wl_shm};
+
+use super::{
+    CursorCaptureSessionData, CursorSession, CursorSessionInner, FrameData, WaylandHelper,
+    wl_transform_to_image_orientation,
+};
+use crate::buffer;
+
+enum State {
+    Waiting,
+    Capturing(oneshot::Receiver<Result<Frame, WEnum<FailureReason>>>),
+}
+
+struct CursorStreamBuffer {
+    fd: OwnedFd,
+    wl_buffer: wl_buffer::WlBuffer,
+    width: u32,
+    height: u32,
+    is_new: bool,
+}
+
+pub struct CursorFrame {
+    pub image: image::RgbaImage,
+    pub hotspot: (i32, i32),
+}
+
+// TODO wake stream when we get formats?
+pub struct CursorStream {
+    state: State,
+    cursor_session: Weak<CursorSessionInner>,
+    capture_session: CaptureSession,
+    wayland_helper: WaylandHelper,
+    buffer: Option<CursorStreamBuffer>,
+}
+
+impl CursorStream {
+    pub(super) fn new(
+        cursor_session: &CursorSession,
+        capture_session: &CaptureSession,
+        wayland_helper: &WaylandHelper,
+    ) -> Self {
+        Self {
+            state: State::Waiting,
+            cursor_session: Arc::downgrade(&cursor_session.0),
+            capture_session: capture_session.clone(),
+            wayland_helper: wayland_helper.clone(),
+            buffer: None,
+        }
+    }
+}
+
+impl futures::stream::Stream for CursorStream {
+    type Item = CursorFrame;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<CursorFrame>> {
+        let stream = self.get_mut();
+
+        let data = stream
+            .capture_session
+            .data::<CursorCaptureSessionData>()
+            .unwrap();
+        *data.waker.lock().unwrap() = Some(cx.waker().clone());
+
+        // Allocate buffer if we don't have one, or resolution has changed
+        if let Some(formats) = &data.formats.lock().unwrap().clone()
+            && stream
+                .buffer
+                .as_ref()
+                .is_none_or(|b| (b.width, b.height) != formats.buffer_size)
+        {
+            let (width, height) = formats.buffer_size;
+            let fd = buffer::create_memfd(width, height);
+            let wl_buffer = stream.wayland_helper.create_shm_buffer(
+                &fd,
+                width,
+                height,
+                width * 4,
+                wl_shm::Format::Argb8888,
+            );
+            stream.buffer = Some(CursorStreamBuffer {
+                width,
+                height,
+                fd,
+                wl_buffer,
+                is_new: true,
+            });
+            stream.state = State::Waiting;
+        }
+
+        // If we are capturing, poll receiver for result
+        if let State::Capturing(receiver) = &mut stream.state {
+            match std::pin::Pin::new(receiver).poll(cx) {
+                Poll::Ready(Ok(Ok(frame))) => {
+                    let Some(cursor_session) = stream.cursor_session.upgrade().map(CursorSession)
+                    else {
+                        return Poll::Ready(None);
+                    };
+
+                    let CursorStreamBuffer {
+                        width,
+                        height,
+                        fd,
+                        is_new,
+                        ..
+                    } = stream.buffer.as_mut().unwrap();
+                    *is_new = false;
+                    let mmap = unsafe { memmap2::Mmap::map(&*fd).unwrap() };
+                    let mut bytes = mmap.to_vec();
+                    // Swap BGRA to RGBA
+                    for pixel in bytes.chunks_mut(4) {
+                        pixel.swap(2, 0);
+                    }
+                    let Some(image) = image::RgbaImage::from_vec(*width, *height, bytes) else {
+                        return Poll::Ready(None);
+                    };
+                    let transform = match frame.transform {
+                        WEnum::Value(value) => value,
+                        WEnum::Unknown(value) => panic!("invalid capture transform: {}", value),
+                    };
+                    let mut image = image::DynamicImage::from(image);
+                    image.apply_orientation(wl_transform_to_image_orientation(transform));
+                    let image = match image {
+                        image::DynamicImage::ImageRgba8(image) => image,
+                        _ => unreachable!(),
+                    };
+                    return Poll::Ready(Some(CursorFrame {
+                        image,
+                        hotspot: cursor_session.cursor_hotspot(),
+                    }));
+                }
+                Poll::Ready(Ok(Err(reason))) => match reason {
+                    WEnum::Value(FailureReason::BufferConstraints) => {
+                        stream.buffer = None;
+                    }
+                    WEnum::Value(FailureReason::Stopped) => {
+                        return Poll::Ready(None);
+                    }
+                    _ => tracing::error!("error in cursor capture: {:?})", reason),
+                },
+                Poll::Ready(Err(futures::channel::oneshot::Canceled)) => {}
+                Poll::Pending => {
+                    return Poll::Pending;
+                }
+            }
+        }
+
+        if let Some(CursorStreamBuffer {
+            width,
+            height,
+            wl_buffer,
+            is_new,
+            ..
+        }) = &stream.buffer
+        {
+            let (sender, receiver) = oneshot::channel();
+            let full_damage = Rect {
+                x: 0,
+                y: 0,
+                width: *width as i32,
+                height: *height as i32,
+            };
+            let damage = if *is_new {
+                std::slice::from_ref(&full_damage)
+            } else {
+                &[]
+            };
+            stream.capture_session.capture(
+                wl_buffer,
+                damage,
+                &stream.wayland_helper.inner.qh,
+                FrameData {
+                    frame_data: Default::default(),
+                    sender: Mutex::new(Some(sender)),
+                },
+            );
+            stream.state = State::Capturing(receiver);
+        }
+
+        Poll::Pending
+    }
+}

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -82,14 +82,13 @@ struct WaylandHelperInner {
     zwp_dmabuf: Option<ZwpLinuxDmabufV1>,
 }
 
-// TODO seperate state object from what is passed to threads
 #[derive(Clone)]
 pub struct WaylandHelper {
     inner: Arc<WaylandHelperInner>,
 }
 
 struct AppData {
-    wayland_helper: WaylandHelper, // TODO: populate outputs
+    wayland_helper: WaylandHelper,
     registry_state: RegistryState,
     screencopy_state: ScreencopyState,
     output_state: OutputState,
@@ -200,7 +199,6 @@ impl Session {
         buffer_damage: &[Rect],
     ) -> Result<Frame, WEnum<FailureReason>> {
         let (sender, receiver) = oneshot::channel();
-        // TODO damage
         self.0.capture_session.capture(
             buffer,
             buffer_damage,
@@ -382,7 +380,6 @@ impl WaylandHelper {
         overlay_cursor: bool,
     ) -> Option<ShmImage<OwnedFd>> {
         // XXX error type?
-        // TODO: way to get cursor metadata?
 
         let session = self.capture_source_session(source, overlay_cursor);
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,5 +1,6 @@
 use cosmic_client_toolkit::screencopy::{
-    CaptureFrame, CaptureOptions, CaptureSession, Capturer, FailureReason, Formats, Frame,
+    CaptureCursorSession, CaptureFrame, CaptureOptions, CaptureSession, Capturer, FailureReason,
+    Formats, Frame, ScreencopyCursorSessionData, ScreencopyCursorSessionDataExt,
     ScreencopyFrameData, ScreencopyFrameDataExt, ScreencopyHandler, ScreencopySessionData,
     ScreencopySessionDataExt, ScreencopyState,
 };
@@ -8,6 +9,8 @@ use cosmic_client_toolkit::sctk::dmabuf::{
 };
 use cosmic_client_toolkit::sctk::output::{OutputHandler, OutputInfo, OutputState};
 use cosmic_client_toolkit::sctk::registry::{ProvidesRegistryState, RegistryState};
+use cosmic_client_toolkit::sctk::seat::pointer::{PointerEvent, PointerHandler};
+use cosmic_client_toolkit::sctk::seat::{self, SeatHandler, SeatState};
 use cosmic_client_toolkit::sctk::shm::{Shm, ShmHandler};
 use cosmic_client_toolkit::sctk::{self};
 use cosmic_client_toolkit::toplevel_info::{ToplevelInfo, ToplevelInfoState};
@@ -16,10 +19,11 @@ use futures::channel::oneshot;
 use futures::stream::{FuturesOrdered, Stream, StreamExt};
 use std::collections::HashMap;
 use std::os::fd::{AsFd, OwnedFd};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::thread;
 use wayland_client::globals::registry_queue_init;
-use wayland_client::protocol::{wl_buffer, wl_output, wl_shm, wl_shm_pool};
+use wayland_client::protocol::{wl_buffer, wl_output, wl_pointer, wl_seat, wl_shm, wl_shm_pool};
 use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
 use wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1;
 use wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1;
@@ -33,6 +37,8 @@ pub use cosmic_client_toolkit::screencopy::{CaptureSource, Rect};
 
 use crate::buffer;
 
+mod cursor_stream;
+pub use cursor_stream::{CursorFrame, CursorStream};
 mod gbm_devices;
 mod toplevel;
 mod workspaces;
@@ -98,6 +104,8 @@ struct WaylandHelperInner {
     wl_shm: wl_shm::WlShm,
     dmabuf: Mutex<Option<DmabufHelper>>,
     zwp_dmabuf: Option<ZwpLinuxDmabufV1>,
+    // TODO: Handle multiple pointers if multi-seat is ever supported.
+    pointer: Mutex<Option<(wl_seat::WlSeat, wl_pointer::WlPointer)>>,
 }
 
 #[derive(Clone)]
@@ -114,6 +122,7 @@ struct AppData {
     dmabuf_state: DmabufState,
     toplevel_info_state: ToplevelInfoState,
     workspace_state: WorkspaceState,
+    seat_state: SeatState,
 }
 
 impl Drop for AppData {
@@ -249,6 +258,37 @@ impl Session {
     }
 }
 
+struct CursorSessionInner {
+    capture_session: CaptureSession,
+    _capture_cursor_session: CaptureCursorSession,
+    cursor_entered: AtomicBool,
+    // Pack x and y into a single atomic
+    cursor_position: AtomicU64,
+    cursor_hotspot: AtomicU64,
+}
+
+pub struct CursorSession(Arc<CursorSessionInner>);
+
+impl CursorSession {
+    pub fn cursor_entered(&self) -> bool {
+        self.0.cursor_entered.load(Ordering::Relaxed)
+    }
+
+    pub fn cursor_position(&self) -> (i32, i32) {
+        let value = self.0.cursor_position.load(Ordering::Relaxed).to_ne_bytes();
+        let x = i32::from_ne_bytes(value[..4].try_into().unwrap());
+        let y = i32::from_ne_bytes(value[4..].try_into().unwrap());
+        (x, y)
+    }
+
+    fn cursor_hotspot(&self) -> (i32, i32) {
+        let value = self.0.cursor_hotspot.load(Ordering::Relaxed).to_ne_bytes();
+        let x = i32::from_ne_bytes(value[..4].try_into().unwrap());
+        let y = i32::from_ne_bytes(value[4..].try_into().unwrap());
+        (x, y)
+    }
+}
+
 impl WaylandHelper {
     pub fn new(conn: wayland_client::Connection) -> Self {
         // XXX unwrap
@@ -270,6 +310,7 @@ impl WaylandHelper {
                 wl_shm: shm_state.wl_shm().clone(),
                 dmabuf: Mutex::new(None),
                 zwp_dmabuf,
+                pointer: Mutex::new(None),
             }),
         };
         let dmabuf_state = DmabufState::new(&globals, &qh);
@@ -285,6 +326,7 @@ impl WaylandHelper {
             workspace_state: WorkspaceState::new(&registry_state, &qh),
             toplevel_info_state: ToplevelInfoState::new(&registry_state, &qh),
             registry_state,
+            seat_state: SeatState::new(&globals, &qh),
         };
         event_queue.flush().unwrap();
 
@@ -440,6 +482,57 @@ impl WaylandHelper {
         } else {
             None
         }
+    }
+
+    pub fn capture_source_cursor_session(
+        &self,
+        source: CaptureSource,
+    ) -> Option<(CursorSession, cursor_stream::CursorStream)> {
+        let pointer = self.inner.pointer.lock().unwrap();
+        let (_, pointer) = pointer.as_ref()?;
+
+        let cursor_session = CursorSession(Arc::new_cyclic(|weak_session| {
+            let capture_cursor_session = self
+                .inner
+                .capturer
+                .create_cursor_session(
+                    &source,
+                    pointer,
+                    &self.inner.qh,
+                    CursorSessionData {
+                        session: weak_session.clone(),
+                        session_data: ScreencopyCursorSessionData::default(),
+                    },
+                )
+                .unwrap();
+
+            let capture_session = capture_cursor_session
+                .capture_session(
+                    &self.inner.qh,
+                    CursorCaptureSessionData {
+                        session_data: ScreencopySessionData::default(),
+                        waker: Mutex::new(None),
+                        formats: Mutex::new(None),
+                    },
+                )
+                .unwrap();
+
+            CursorSessionInner {
+                capture_session,
+                _capture_cursor_session: capture_cursor_session,
+                cursor_entered: AtomicBool::new(false),
+                cursor_position: AtomicU64::new(0),
+                cursor_hotspot: AtomicU64::new(0),
+            }
+        }));
+
+        let cursor_stream = cursor_stream::CursorStream::new(
+            &cursor_session,
+            &cursor_session.0.capture_session,
+            self,
+        );
+
+        Some((cursor_session, cursor_stream))
     }
 
     pub fn create_shm_buffer<Fd: AsFd>(
@@ -611,6 +704,12 @@ impl ScreencopyHandler for AppData {
             session.update(|data| {
                 data.formats = Some(formats.clone());
             });
+        } else if let Some(data) = session.data::<CursorCaptureSessionData>() {
+            *data.formats.lock().unwrap() = Some(formats.clone());
+            let waker = data.waker.lock().unwrap();
+            if let Some(waker) = &*waker {
+                waker.wake_by_ref();
+            }
         }
     }
 
@@ -650,6 +749,66 @@ impl ScreencopyHandler for AppData {
             .and_then(|data| data.sender.lock().unwrap().take())
         {
             let _ = sender.send(Err(reason));
+        }
+    }
+
+    fn cursor_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        session: &CaptureCursorSession,
+    ) {
+        let data = session.data::<CursorSessionData>().unwrap();
+        if let Some(session) = data.session.upgrade() {
+            session.cursor_entered.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn cursor_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        session: &CaptureCursorSession,
+    ) {
+        let data = session.data::<CursorSessionData>().unwrap();
+        if let Some(session) = data.session.upgrade() {
+            session.cursor_entered.store(false, Ordering::Relaxed);
+        }
+    }
+
+    fn cursor_position(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        session: &CaptureCursorSession,
+        x: i32,
+        y: i32,
+    ) {
+        let data = session.data::<CursorSessionData>().unwrap();
+        if let Some(session) = data.session.upgrade() {
+            let mut value = [0; 8];
+            value[..4].copy_from_slice(&x.to_ne_bytes());
+            value[4..].copy_from_slice(&y.to_ne_bytes());
+            let value = u64::from_ne_bytes(value);
+            session.cursor_position.store(value, Ordering::Relaxed);
+        }
+    }
+
+    fn cursor_hotspot(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        session: &CaptureCursorSession,
+        x: i32,
+        y: i32,
+    ) {
+        let data = session.data::<CursorSessionData>().unwrap();
+        if let Some(session) = data.session.upgrade() {
+            let mut value = [0; 8];
+            value[..4].copy_from_slice(&x.to_ne_bytes());
+            value[4..].copy_from_slice(&y.to_ne_bytes());
+            let value = u64::from_ne_bytes(value);
+            session.cursor_hotspot.store(value, Ordering::Relaxed);
         }
     }
 }
@@ -701,6 +860,64 @@ impl DmabufHandler for AppData {
     }
 }
 
+impl SeatHandler for AppData {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+
+    fn new_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: wl_seat::WlSeat) {}
+
+    fn new_capability(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: seat::Capability,
+    ) {
+        if capability == seat::Capability::Pointer {
+            let pointer = self.seat_state.get_pointer(qh, &seat).unwrap();
+            *self.wayland_helper.inner.pointer.lock().unwrap() = Some((seat, pointer));
+        }
+    }
+
+    fn remove_capability(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: seat::Capability,
+    ) {
+        if capability == seat::Capability::Pointer {
+            self.wayland_helper
+                .inner
+                .pointer
+                .lock()
+                .unwrap()
+                .take_if(|(s, _)| *s == seat);
+        }
+    }
+
+    fn remove_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, seat: wl_seat::WlSeat) {
+        self.wayland_helper
+            .inner
+            .pointer
+            .lock()
+            .unwrap()
+            .take_if(|(s, _)| *s == seat);
+    }
+}
+
+impl PointerHandler for AppData {
+    fn pointer_frame(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        _events: &[PointerEvent],
+    ) {
+    }
+}
+
 impl Dispatch<wl_shm_pool::WlShmPool, ()> for AppData {
     fn event(
         _app_data: &mut Self,
@@ -736,6 +953,29 @@ impl ScreencopySessionDataExt for SessionData {
     }
 }
 
+struct CursorSessionData {
+    session: Weak<CursorSessionInner>,
+    session_data: ScreencopyCursorSessionData,
+}
+
+impl ScreencopyCursorSessionDataExt for CursorSessionData {
+    fn screencopy_cursor_session_data(&self) -> &ScreencopyCursorSessionData {
+        &self.session_data
+    }
+}
+
+struct CursorCaptureSessionData {
+    session_data: ScreencopySessionData,
+    waker: Mutex<Option<std::task::Waker>>,
+    formats: Mutex<Option<Formats>>,
+}
+
+impl ScreencopySessionDataExt for CursorCaptureSessionData {
+    fn screencopy_session_data(&self) -> &ScreencopySessionData {
+        &self.session_data
+    }
+}
+
 struct FrameData {
     frame_data: ScreencopyFrameData,
     #[allow(clippy::type_complexity)]
@@ -752,4 +992,6 @@ sctk::delegate_shm!(AppData);
 sctk::delegate_registry!(AppData);
 sctk::delegate_output!(AppData);
 sctk::delegate_dmabuf!(AppData);
+sctk::delegate_seat!(AppData);
+sctk::delegate_pointer!(AppData);
 cosmic_client_toolkit::delegate_screencopy!(AppData);

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -84,14 +84,13 @@ struct WaylandHelperInner {
     zwp_dmabuf: Option<ZwpLinuxDmabufV1>,
 }
 
-// TODO seperate state object from what is passed to threads
 #[derive(Clone)]
 pub struct WaylandHelper {
     inner: Arc<WaylandHelperInner>,
 }
 
 struct AppData {
-    wayland_helper: WaylandHelper, // TODO: populate outputs
+    wayland_helper: WaylandHelper,
     registry_state: RegistryState,
     screencopy_state: ScreencopyState,
     output_state: OutputState,
@@ -209,7 +208,6 @@ impl Session {
         buffer_damage: &[Rect],
     ) -> Result<Frame, WEnum<FailureReason>> {
         let (sender, receiver) = oneshot::channel();
-        // TODO damage
         self.0.capture_session.capture(
             buffer,
             buffer_damage,
@@ -391,7 +389,6 @@ impl WaylandHelper {
         overlay_cursor: bool,
     ) -> Option<ShmImage<OwnedFd>> {
         // XXX error type?
-        // TODO: way to get cursor metadata?
 
         let session = self.capture_source_session(source, overlay_cursor);
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -37,6 +37,22 @@ mod gbm_devices;
 mod toplevel;
 mod workspaces;
 
+fn wl_transform_to_image_orientation(
+    transform: wl_output::Transform,
+) -> image::metadata::Orientation {
+    match transform {
+        wl_output::Transform::Normal => image::metadata::Orientation::NoTransforms,
+        wl_output::Transform::_90 => image::metadata::Orientation::Rotate90,
+        wl_output::Transform::_180 => image::metadata::Orientation::Rotate180,
+        wl_output::Transform::_270 => image::metadata::Orientation::Rotate270,
+        wl_output::Transform::Flipped => image::metadata::Orientation::FlipHorizontal,
+        wl_output::Transform::Flipped90 => image::metadata::Orientation::Rotate90FlipH,
+        wl_output::Transform::Flipped180 => image::metadata::Orientation::FlipVertical,
+        wl_output::Transform::Flipped270 => image::metadata::Orientation::Rotate270FlipH,
+        _ => unreachable!(),
+    }
+}
+
 #[derive(Clone)]
 pub struct DmabufHelper {
     feedback: Arc<DmabufFeedback>,
@@ -506,17 +522,7 @@ impl<T: AsFd> ShmImage<T> {
 
     pub fn image_transformed(&self) -> anyhow::Result<image::RgbaImage> {
         let mut image = image::DynamicImage::from(self.image()?);
-        image.apply_orientation(match self.transform {
-            wl_output::Transform::Normal => image::metadata::Orientation::NoTransforms,
-            wl_output::Transform::_90 => image::metadata::Orientation::Rotate90,
-            wl_output::Transform::_180 => image::metadata::Orientation::Rotate180,
-            wl_output::Transform::_270 => image::metadata::Orientation::Rotate270,
-            wl_output::Transform::Flipped => image::metadata::Orientation::FlipHorizontal,
-            wl_output::Transform::Flipped90 => image::metadata::Orientation::Rotate90FlipH,
-            wl_output::Transform::Flipped180 => image::metadata::Orientation::FlipVertical,
-            wl_output::Transform::Flipped270 => image::metadata::Orientation::Rotate270FlipH,
-            _ => unreachable!(),
-        });
+        image.apply_orientation(wl_transform_to_image_orientation(self.transform));
         match image {
             image::DynamicImage::ImageRgba8(image) => Ok(image),
             _ => unreachable!(),


### PR DESCRIPTION
This has some code for passing cursor metadata over pipewire; it still needs to correctly set cursor position and image using that. This will require https://github.com/pop-os/cosmic-protocols/pull/60.

OBS support this, and it is how it is possible to toggle the cursor mode in OBS without it recreating the capture session.