### PR TITLE
WIP Use DBus socket activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,10 @@ $(BIN): Cargo.toml Cargo.lock src/main.rs vendor-check
 
 install:
 	install -Dm0755 $(CARGO_TARGET_DIR)/$(TARGET)/$(BIN) $(DESTDIR)$(libexecdir)/$(BIN)
-	install -Dm0644 data/$(DBUS_NAME).service $(DESTDIR)$(datadir)/dbus-1/services/$(DBUS_NAME).service
+	sed "s|LIBEXECDIR|$(libexecdir)|" data/dbus-1/$(DBUS_NAME).service.in > data/dbus-1/$(DBUS_NAME).service
+	install -Dm0644 data/dbus-1/$(DBUS_NAME).service $(DESTDIR)$(datadir)/dbus-1/services/$(DBUS_NAME).service
+	sed "s|LIBEXECDIR|$(libexecdir)|" data/$(DBUS_NAME).service.in > data/$(DBUS_NAME).service
+	install -Dm0644 data/$(DBUS_NAME).service $(DESTDIR)$(libdir)/systemd/user/$(DBUS_NAME).service
 	install -Dm0644 data/cosmic.portal $(DESTDIR)$(datadir)/xdg-desktop-portal/portals/cosmic.portal
 	install -Dm0644 data/cosmic-portals.conf $(DESTDIR)$(datadir)/xdg-desktop-portal/cosmic-portals.conf
 	find 'data'/'icons' -type f -exec echo {} \; \

--- a/data/dbus-1/org.freedesktop.impl.portal.desktop.cosmic.service.in
+++ b/data/dbus-1/org.freedesktop.impl.portal.desktop.cosmic.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.desktop.cosmic
-Exec=/bin/false
+Exec=LIBEXECDIR/xdg-desktop-portal-cosmic

--- a/data/org.freedesktop.impl.portal.desktop.cosmic.service.in
+++ b/data/org.freedesktop.impl.portal.desktop.cosmic.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=Portal service (COSMIC implementation)
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.impl.portal.desktop.cosmic
+ExecStart=LIBEXECDIR/xdg-desktop-portal-cosmic


### PR DESCRIPTION
`xdg-desktop-portal` generally expects DBus socket activation to work, so it was a little hacky not to use this, though seems to have largely worked.

But I think we've decided now that we don't need a specially assigned privileged Wayland socket for the portal backend (sandbox engines should now be using security-context-v1, so they won't expose these protocols.)

Not sure how best to substitute configurable paths into these files when installing. I can't recall if there was somewhere we had something similar.