### PR TITLE
fixed makefile to install in the correct place.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-prefix ?= /usr/local
+prefix ?= /usr
 bindir = $(prefix)/bin
 libdir = $(prefix)/lib
 libexecdir = $(prefix)/libexec


### PR DESCRIPTION
This changes the install location from /usr/local/libexec to /usr/libexec which seems to be the appropriate place to install to. (for changes to actually take place).