### PR TITLE
feat: add ctrl+c, ctrl+s functionality to cosmic-screenshot

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -230,7 +230,7 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
             .icon(icon)
             .secondary_action(cancel_button)
             .primary_action(allow_button),
-        |key| match key {
+        |key, _| match key {
             Key::Named(Named::Enter) => Some(Msg::Allow),
             Key::Named(Named::Escape) => Some(Msg::Cancel),
             _ => None,

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -455,7 +455,7 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
                 .secondary_action(cancel_button)
                 .primary_action(share_button)
                 .control(control),
-            |key| match key {
+            |key, _| match key {
                 Key::Named(Named::Enter) => Some(Msg::Share),
                 Key::Named(Named::Escape) => Some(Msg::Cancel),
                 _ => None,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -353,6 +353,7 @@ fn write_png<W: io::Write>(w: W, image: &RgbaImage) -> Result<(), png::EncodingE
 #[derive(Debug, Clone)]
 pub enum Msg {
     Capture,
+    CaptureWithLocation(ImageSaveLocation),
     Cancel,
     Choice(Choice),
     OutputChanged(WlOutput),
@@ -579,10 +580,32 @@ pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<'_,
             theme.spacing,
             i as u128,
         ),
-        |key| match key {
-            Key::Named(Named::Enter) => Some(Msg::Capture),
-            Key::Named(Named::Escape) => Some(Msg::Cancel),
-            _ => None,
+        |key, modifiers| {
+            if modifiers.control() {
+                match key {
+                    Key::Named(Named::Copy) => {
+                        return Some(Msg::CaptureWithLocation(ImageSaveLocation::Clipboard));
+                    }
+                    Key::Named(Named::Save) => {
+                        return Some(Msg::CaptureWithLocation(ImageSaveLocation::Pictures));
+                    }
+                    Key::Character(ref value) => {
+                        let value = value.as_str();
+                        if value.eq_ignore_ascii_case("c") {
+                            return Some(Msg::CaptureWithLocation(ImageSaveLocation::Clipboard));
+                        } else if value.eq_ignore_ascii_case("s") {
+                            return Some(Msg::CaptureWithLocation(ImageSaveLocation::Pictures));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            match key {
+                Key::Named(Named::Enter) => Some(Msg::Capture),
+                Key::Named(Named::Escape) => Some(Msg::Cancel),
+                _ => None,
+            }
         },
     )
     .into()
@@ -724,6 +747,15 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
                 }
             });
             cosmic::Task::batch(cmds)
+        }
+        Msg::CaptureWithLocation(location) => {
+            if let Some(args) = portal.screenshot_args.as_mut() {
+                args.location = location;
+            } else {
+                log::error!("Failed to find screenshot Args for CaptureWithLocation message.");
+                return cosmic::Task::none();
+            }
+            update_msg(portal, Msg::Capture)
         }
         Msg::Cancel => {
             let cmds = portal.outputs.iter().map(|o| destroy_layer_surface(o.id));

--- a/src/widget/keyboard_wrapper.rs
+++ b/src/widget/keyboard_wrapper.rs
@@ -8,14 +8,14 @@ use cosmic::iced_core::{
 #[allow(missing_debug_implementations)]
 pub struct KeyboardWrapper<'a, Message> {
     content: Element<'a, Message, cosmic::Theme, cosmic::Renderer>,
-    handler: fn(keyboard::Key) -> Option<Message>,
+    handler: fn(keyboard::Key, keyboard::Modifiers) -> Option<Message>,
 }
 
 impl<'a, Message> KeyboardWrapper<'a, Message> {
     /// Creates a [`KeyboardWrapper`] with the given content.
     pub fn new(
         content: impl Into<Element<'a, Message, cosmic::Theme, cosmic::Renderer>>,
-        handler: fn(keyboard::Key) -> Option<Message>,
+        handler: fn(keyboard::Key, keyboard::Modifiers) -> Option<Message>,
     ) -> Self {
         KeyboardWrapper {
             content: content.into(),
@@ -88,8 +88,8 @@ where
         }
 
         match event {
-            Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
-                if let Some(message) = (self.handler)(key) {
+            Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) => {
+                if let Some(message) = (self.handler)(key, modifiers) {
                     shell.publish(message.clone());
                     event::Status::Captured
                 } else {


### PR DESCRIPTION
## Summary

Allow users to override the currently-selected save location using `ctrl+c` or `ctrl+s`.

## Motivation

This is a feature a few other screenshot tools have and which I've wanted in COSMIC for a while!