### PR TITLE
remember last screenshot rectangle

### DIFF
--- a/cosmic-portal-config/src/screenshot.rs
+++ b/cosmic-portal-config/src/screenshot.rs
@@ -2,11 +2,22 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Logical coordinates of a rectangle selection
+#[derive(Debug, Clone, Copy, Default, PartialEq, Deserialize, Serialize)]
+pub struct Rect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Screenshot {
     pub save_location: ImageSaveLocation,
     pub choice: Choice,
+    #[serde(default)]
+    pub last_rectangle: Option<Rect>,
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
## Problem

On pop-os 22.04 the "screenshot a selected area" was more intuitive: the previously selected area would be the default selection for a subsequent screenshot. On 24.04, you must re-select the rectangle for every screenshot.

## Solution

Remember the last rectangle, returning to the old, more intuitive behavior.

## Testing

Build & run like

```
cargo build --release
systemctl --user stop org.freedesktop.impl.portal.desktop.cosmic && ./target/release/xdg-desktop-portal-cosmic
```

Then take one screenshot using a selected area.

On master, taking another screenshot will require you to re-select the area. Here, the last-used rectangle will remain