### PR TITLE
Implement full RemoteDesktop portal with consent dialog and EIS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ memmap2 = "0.9.8"
 pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", features = [
     "v0_3_33",
 ] }
+reis = { version = "0.5", features = ["tokio"] }
 png = "0.18"
 rustix = { version = "1.1", features = ["fs"] }
 # spa_sys = { package = "libspa-sys", git = "https://github.com/pop-os/pipewire-rs" }

--- a/i18n/en/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/en/xdg_desktop_portal_cosmic.ftl
@@ -13,3 +13,9 @@ share-screen = Share your screen
 unknown-application = Unknown Application
 output = Output
 window = Window
+
+remote-desktop-access = Remote Desktop Access
+    .description = "{$app_name}" is requesting remote control of your desktop. The following inputs will be shared:
+remote-desktop-keyboard = keyboard
+remote-desktop-pointer = pointer
+remote-desktop-touchscreen = touchscreen

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod documents;
 mod file_chooser;
 mod localize;
 mod remote_desktop;
+mod remote_desktop_dialog;
 mod screencast;
 mod screencast_dialog;
 mod screencast_thread;

--- a/src/remote_desktop.rs
+++ b/src/remote_desktop.rs
@@ -1,10 +1,31 @@
-use crate::{PortalResponse, Session};
-use std::{
-    collections::HashMap,
-    env,
-    os::{fd::OwnedFd, unix::net::UnixStream},
-};
+#![allow(dead_code, unused_variables)]
+
+use std::collections::HashMap;
+use std::os::unix::net::UnixStream;
+use std::{io, mem};
+
+use ashpd::desktop::screencast::SourceType;
+use ashpd::enumflags2::BitFlags;
+use futures::stream::{FuturesOrdered, StreamExt};
+use tokio::sync::mpsc::Sender;
 use zbus::zvariant;
+
+use crate::remote_desktop_dialog::{self, CaptureSources};
+use crate::screencast::StreamProps;
+use crate::screencast_thread::ScreencastThread;
+use crate::subscription;
+use crate::wayland::{CaptureSource, WaylandHelper};
+use crate::{PortalResponse, Request};
+
+const DEVICE_KEYBOARD: u32 = 1;
+const DEVICE_POINTER: u32 = 2;
+const DEVICE_TOUCHSCREEN: u32 = 4;
+
+const CURSOR_MODE_HIDDEN: u32 = 1;
+const CURSOR_MODE_EMBEDDED: u32 = 2;
+
+const SOURCE_TYPE_MONITOR: u32 = 1;
+const SOURCE_TYPE_WINDOW: u32 = 2;
 
 #[derive(zvariant::SerializeDict, zvariant::Type)]
 #[zvariant(signature = "a{sv}")]
@@ -12,13 +33,104 @@ struct CreateSessionResult {
     session_id: String,
 }
 
+#[derive(Clone)]
+struct PersistedCaptureSources {
+    pub outputs: Vec<String>,
+    pub toplevels: Vec<String>,
+}
+
+impl PersistedCaptureSources {
+    fn from_capture_sources(
+        wayland_helper: &WaylandHelper,
+        sources: &CaptureSources,
+    ) -> Option<Self> {
+        let mut outputs = Vec::new();
+        for handle in &sources.outputs {
+            let info = wayland_helper.output_info(handle)?;
+            outputs.push(info.name.clone()?);
+        }
+
+        let mut toplevels = Vec::new();
+        let toplevel_infos = wayland_helper.toplevels();
+        for handle in &sources.toplevels {
+            let info = toplevel_infos
+                .iter()
+                .find(|t| t.foreign_toplevel == *handle)?;
+            toplevels.push(info.identifier.clone());
+        }
+
+        Some(Self { outputs, toplevels })
+    }
+
+    fn to_capture_sources(&self, wayland_helper: &WaylandHelper) -> Option<CaptureSources> {
+        let mut outputs = Vec::new();
+        for name in &self.outputs {
+            outputs.push(wayland_helper.output_for_name(name)?);
+        }
+
+        let mut toplevels = Vec::new();
+        let toplevel_infos = wayland_helper.toplevels();
+        for identifier in &self.toplevels {
+            let info = toplevel_infos
+                .iter()
+                .find(|t| t.identifier == *identifier)?;
+            toplevels.push(info.foreign_toplevel.clone());
+        }
+
+        Some(CaptureSources { outputs, toplevels })
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, zvariant::Type)]
+#[zvariant(signature = "(suv)")]
+struct RestoreData {
+    vendor: String,
+    version: u32,
+    data: zvariant::OwnedValue,
+}
+
+impl From<PersistedCaptureSources> for RestoreData {
+    fn from(sources: PersistedCaptureSources) -> RestoreData {
+        RestoreData {
+            vendor: "COSMIC".to_string(),
+            version: 1,
+            data: zvariant::Value::from(zvariant::Structure::from((
+                sources.outputs,
+                sources.toplevels,
+            )))
+            .try_to_owned()
+            .unwrap(),
+        }
+    }
+}
+
+impl TryFrom<&RestoreData> for PersistedCaptureSources {
+    type Error = ();
+    fn try_from(restore_data: &RestoreData) -> Result<Self, ()> {
+        if (&*restore_data.vendor, restore_data.version) != ("COSMIC", 1) {
+            return Err(());
+        }
+        let structure = zvariant::Structure::try_from(&*restore_data.data).map_err(|_| ())?;
+        let (outputs, toplevels) = structure.try_into().map_err(|_| ())?;
+        Ok(PersistedCaptureSources { outputs, toplevels })
+    }
+}
+
 #[derive(zvariant::DeserializeDict, zvariant::Type)]
 #[zvariant(signature = "a{sv}")]
 struct SelectDevicesOptions {
-    // Default: all
     types: Option<u32>,
-    restore_data: Option<(String, u32, zvariant::OwnedValue)>,
-    // Default: 0
+    restore_data: Option<RestoreData>,
+    persist_mode: Option<u32>,
+}
+
+#[derive(zvariant::DeserializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+struct SelectSourcesOptions {
+    types: Option<u32>,
+    multiple: Option<bool>,
+    cursor_mode: Option<u32>,
+    restore_data: Option<RestoreData>,
     persist_mode: Option<u32>,
 }
 
@@ -26,13 +138,43 @@ struct SelectDevicesOptions {
 #[zvariant(signature = "a{sv}")]
 struct StartResult {
     devices: u32,
-    clipboard_enabled: bool,
-    streams: Vec<(u32, HashMap<String, zvariant::OwnedValue>)>,
+    streams: Vec<(u32, StreamProps)>,
+    persist_mode: Option<u32>,
+    restore_data: Option<RestoreData>,
 }
 
-struct SessionData {}
+#[derive(Default)]
+struct SessionData {
+    device_types: u32,
+    screencast_threads: Vec<ScreencastThread>,
+    cursor_mode: Option<u32>,
+    multiple: bool,
+    source_types: BitFlags<SourceType>,
+    persisted_capture_sources: Option<PersistedCaptureSources>,
+    eis_socket_client: Option<zvariant::OwnedFd>,
+    closed: bool,
+}
 
-pub struct RemoteDesktop;
+impl SessionData {
+    fn close(&mut self) {
+        for thread in mem::take(&mut self.screencast_threads) {
+            thread.stop();
+        }
+        self.eis_socket_client.take();
+        self.closed = true;
+    }
+}
+
+pub struct RemoteDesktop {
+    wayland_helper: WaylandHelper,
+    tx: Sender<subscription::Event>,
+}
+
+impl RemoteDesktop {
+    pub fn new(wayland_helper: WaylandHelper, tx: Sender<subscription::Event>) -> Self {
+        Self { wayland_helper, tx }
+    }
+}
 
 #[zbus::interface(name = "org.freedesktop.impl.portal.RemoteDesktop")]
 impl RemoteDesktop {
@@ -44,26 +186,85 @@ impl RemoteDesktop {
         app_id: String,
         options: HashMap<String, zvariant::OwnedValue>,
     ) -> PortalResponse<CreateSessionResult> {
-        connection
+        let session_data = SessionData::default();
+        if let Err(err) = connection
             .object_server()
-            .at(&session_handle, Session::new(SessionData {}, |_| {}))
+            .at(
+                &session_handle,
+                crate::Session::new(session_data, |session_data| session_data.close()),
+            )
             .await
-            .unwrap(); // XXX unwrap
+        {
+            log::error!("Failed to register session object: {}", err);
+            return PortalResponse::Other;
+        }
         PortalResponse::Success(CreateSessionResult {
-            session_id: "foo".to_string(), // XXX
+            session_id: session_handle
+                .as_str()
+                .rsplit('/')
+                .next()
+                .unwrap_or("remote")
+                .to_string(),
         })
     }
 
-    // CreateSession
     async fn select_devices(
         &self,
         #[zbus(connection)] connection: &zbus::Connection,
         handle: zvariant::ObjectPath<'_>,
         session_handle: zvariant::ObjectPath<'_>,
         app_id: String,
-        options: SelectDevicesOptions, // XXX
+        options: SelectDevicesOptions,
     ) -> PortalResponse<HashMap<String, zvariant::OwnedValue>> {
-        PortalResponse::Success(HashMap::new())
+        match crate::session_interface::<SessionData>(connection, &session_handle).await {
+            Some(interface) => {
+                let mut session_data = interface.get_mut().await;
+                // Mask to valid device type bits only (keyboard, pointer, touchscreen).
+                let raw_types = options.types.unwrap_or(DEVICE_KEYBOARD | DEVICE_POINTER);
+                session_data.device_types =
+                    raw_types & (DEVICE_KEYBOARD | DEVICE_POINTER | DEVICE_TOUCHSCREEN);
+                if let Some(restore_data) = &options.restore_data {
+                    if let Ok(persisted) = restore_data.try_into() {
+                        session_data.persisted_capture_sources = Some(persisted);
+                    } else {
+                        log::warn!("unrecognized remote desktop restore data: {:?}", restore_data);
+                    }
+                }
+                PortalResponse::Success(HashMap::new())
+            }
+            None => PortalResponse::Other,
+        }
+    }
+
+    async fn select_sources(
+        &self,
+        #[zbus(connection)] connection: &zbus::Connection,
+        handle: zvariant::ObjectPath<'_>,
+        session_handle: zvariant::ObjectPath<'_>,
+        app_id: String,
+        options: SelectSourcesOptions,
+    ) -> PortalResponse<HashMap<String, zvariant::OwnedValue>> {
+        match crate::session_interface::<SessionData>(connection, &session_handle).await {
+            Some(interface) => {
+                let mut session_data = interface.get_mut().await;
+                session_data.cursor_mode = options.cursor_mode;
+                session_data.multiple = options.multiple.unwrap_or(false);
+                session_data.source_types =
+                    BitFlags::from_bits_truncate(options.types.unwrap_or(0));
+                if session_data.source_types.is_empty() {
+                    session_data.source_types = SourceType::Monitor.into();
+                }
+                if let Some(restore_data) = &options.restore_data {
+                    if let Ok(persisted) = restore_data.try_into() {
+                        session_data.persisted_capture_sources = Some(persisted);
+                    } else {
+                        log::warn!("unrecognized remote desktop restore data: {:?}", restore_data);
+                    }
+                }
+                PortalResponse::Success(HashMap::new())
+            }
+            None => PortalResponse::Other,
+        }
     }
 
     async fn start(
@@ -75,41 +276,228 @@ impl RemoteDesktop {
         parent_window: String,
         options: HashMap<String, zvariant::OwnedValue>,
     ) -> PortalResponse<StartResult> {
-        PortalResponse::Success(StartResult {
-            devices: 7,
-            clipboard_enabled: false,
-            streams: Vec::new(),
+        let on_cancel =
+            || remote_desktop_dialog::hide_remote_desktop_prompt(&self.tx, &session_handle);
+        Request::run(connection, &handle, on_cancel, async {
+            let Some(interface) =
+                crate::session_interface::<SessionData>(connection, &session_handle).await
+            else {
+                return PortalResponse::Other;
+            };
+
+            let (device_types, cursor_mode, multiple, source_types) = {
+                let session_data = interface.get_mut().await;
+                let device_types = session_data.device_types;
+                let cursor_mode = session_data.cursor_mode.unwrap_or(CURSOR_MODE_HIDDEN);
+                let multiple = session_data.multiple;
+                let source_types = session_data.source_types;
+                (device_types, cursor_mode, multiple, source_types)
+            };
+
+            let outputs = self.wayland_helper.outputs();
+            if outputs.is_empty() {
+                log::error!("No output");
+                return PortalResponse::Other;
+            }
+
+            // Always show consent dialog for RemoteDesktop sessions.
+            // Unlike ScreenCast (view-only), RemoteDesktop grants input injection
+            // (keyboard/mouse/touch), which is too sensitive to skip consent based
+            // on restore data alone — output names are guessable and restore data
+            // can be crafted by any D-Bus client.
+            let capture_sources = {
+                let resp = remote_desktop_dialog::show_remote_desktop_prompt(
+                    &self.tx,
+                    &session_handle,
+                    app_id,
+                    device_types,
+                    !source_types.is_empty(),
+                    multiple,
+                    source_types,
+                    &self.wayland_helper,
+                )
+                .await;
+                let Some(capture_sources) = resp else {
+                    log::info!("Remote desktop access denied by user");
+                    return PortalResponse::Cancelled;
+                };
+                capture_sources
+            };
+
+            // Set up screencast threads for video (reuse ScreenCast infra)
+            let overlay_cursor = cursor_mode == CURSOR_MODE_EMBEDDED;
+            let mut res_futures = FuturesOrdered::new();
+            for output in &capture_sources.outputs {
+                let info = self.wayland_helper.output_info(output);
+                let (position, size) = if let Some(info) = info {
+                    (info.logical_position, info.logical_size.unwrap_or((0, 0)))
+                } else {
+                    (Some((0, 0)), (0, 0))
+                };
+                res_futures.push_back(ScreencastThread::new(
+                    self.wayland_helper.clone(),
+                    CaptureSource::Output(output.clone()),
+                    overlay_cursor,
+                    StreamProps::new(position, size, SOURCE_TYPE_MONITOR),
+                ));
+            }
+            let toplevel_infos = self.wayland_helper.toplevels();
+            for foreign_toplevel in &capture_sources.toplevels {
+                let info = toplevel_infos
+                    .iter()
+                    .find(|info| info.foreign_toplevel == *foreign_toplevel);
+                let size = if let Some(info) = info {
+                    info.geometry
+                        .values()
+                        .max_by_key(|info| info.width * info.height)
+                        .map_or((0, 0), |info| (info.width, info.height))
+                } else {
+                    (0, 0)
+                };
+                res_futures.push_back(ScreencastThread::new(
+                    self.wayland_helper.clone(),
+                    CaptureSource::Toplevel(foreign_toplevel.clone()),
+                    overlay_cursor,
+                    StreamProps::new(None, size, SOURCE_TYPE_WINDOW),
+                ));
+            }
+
+            let mut failed = false;
+            let mut screencast_threads = Vec::new();
+            while let Some(res) = res_futures.next().await {
+                match res {
+                    Ok(thread) => screencast_threads.push(thread),
+                    Err(err) => {
+                        log::error!("Screencast thread failed: {}", err);
+                        failed = true;
+                    }
+                }
+            }
+
+            if failed {
+                for thread in screencast_threads {
+                    thread.stop();
+                }
+                return PortalResponse::Other;
+            }
+
+            if interface.get().await.closed {
+                for thread in screencast_threads {
+                    thread.stop();
+                }
+                return PortalResponse::Cancelled;
+            }
+
+            // Create EIS socket pair for input injection
+            let eis_client_fd = match create_eis_socket_pair() {
+                Ok((server_fd, client_fd)) => {
+                    // Forward the server-side fd to the compositor via D-Bus
+                    // Must use the portal's own connection so the compositor's
+                    // auth check sees the well-known name owner match.
+                    if let Err(err) = send_eis_to_compositor(connection, server_fd).await {
+                        log::warn!("Failed to send EIS socket to compositor: {}", err);
+                    }
+                    Some(client_fd)
+                }
+                Err(err) => {
+                    log::error!("Failed to create EIS socket pair: {}", err);
+                    None
+                }
+            };
+
+            let streams = screencast_threads
+                .iter()
+                .map(|thread| (thread.node_id(), thread.stream_props()))
+                .collect();
+
+            {
+                let mut session_data = interface.get_mut().await;
+                session_data.screencast_threads = screencast_threads;
+                session_data.eis_socket_client = eis_client_fd;
+            }
+
+            PortalResponse::Success(StartResult {
+                devices: device_types,
+                streams,
+                persist_mode: None,
+                // Never return restore data for RemoteDesktop sessions.
+                // Input injection is too sensitive to allow any restore-based shortcuts.
+                restore_data: None,
+            })
         })
+        .await
     }
 
-    async fn connect_to_EIS(
+    #[zbus(name = "ConnectToEIS")]
+    async fn connect_to_eis(
         &self,
         #[zbus(connection)] connection: &zbus::Connection,
         session_handle: zvariant::ObjectPath<'_>,
         app_id: String,
         options: HashMap<String, zvariant::OwnedValue>,
-    ) -> zvariant::Fd<'_> {
-        println!("Connect");
-        // TODO Dedicated mechanism to get fd, for specific "devices"
-        if let Ok(path) = env::var("LIBEI_SOCKET") {
-            if let Ok(socket) = UnixStream::connect(path) {
-                return OwnedFd::from(socket).into();
-            }
-        }
+    ) -> zbus::fdo::Result<zvariant::OwnedFd> {
+        let Some(interface) =
+            crate::session_interface::<SessionData>(connection, &session_handle).await
+        else {
+            return Err(zbus::fdo::Error::Failed(
+                "EIS connection unavailable".to_string(),
+            ));
+        };
 
-        todo!()
-        //PortalResponse::Other
+        let mut session_data = interface.get_mut().await;
+        if session_data.closed {
+            return Err(zbus::fdo::Error::Failed(
+                "EIS connection unavailable".to_string(),
+            ));
+        }
+        match session_data.eis_socket_client.take() {
+            Some(fd) => Ok(fd),
+            None => Err(zbus::fdo::Error::Failed(
+                "EIS connection unavailable".to_string(),
+            )),
+        }
     }
 
-    // TODO: Notify*
-
     #[zbus(property)]
-    async fn available_device_types(&self) -> u32 {
-        7 // XXX
+    fn available_device_types(&self) -> u32 {
+        DEVICE_KEYBOARD | DEVICE_POINTER
     }
 
     #[zbus(property, name = "version")]
-    async fn version(&self) -> u32 {
+    fn version(&self) -> u32 {
         2
     }
+}
+
+fn create_eis_socket_pair() -> io::Result<(std::os::fd::OwnedFd, zvariant::OwnedFd)> {
+    let (server, client) = UnixStream::pair()?;
+    Ok((
+        std::os::fd::OwnedFd::from(server),
+        zvariant::OwnedFd::from(std::os::fd::OwnedFd::from(client)),
+    ))
+}
+
+/// Send the server-side EIS socket fd to the compositor via D-Bus.
+///
+/// Uses the portal's own D-Bus connection so the compositor's auth check
+/// can verify the caller owns the portal's well-known name.
+async fn send_eis_to_compositor(
+    connection: &zbus::Connection,
+    server_fd: std::os::fd::OwnedFd,
+) -> anyhow::Result<()> {
+    let proxy = zbus::Proxy::new(
+        connection,
+        "com.system76.CosmicComp.RemoteDesktop",
+        "/com/system76/CosmicComp",
+        "com.system76.CosmicComp.RemoteDesktop",
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create compositor proxy: {}", e))?;
+
+    proxy
+        .call_method("AcceptEisSocket", &(zvariant::Fd::from(server_fd),))
+        .await
+        .map_err(|e| anyhow::anyhow!("D-Bus call to compositor failed: {}", e))?;
+    log::info!("Successfully sent EIS socket to compositor");
+    Ok(())
 }

--- a/src/remote_desktop_dialog.rs
+++ b/src/remote_desktop_dialog.rs
@@ -1,0 +1,541 @@
+use crate::app::CosmicPortal;
+use crate::fl;
+use crate::wayland::{CaptureSource, WaylandHelper};
+use crate::widget::keyboard_wrapper::KeyboardWrapper;
+use ashpd::desktop::screencast::SourceType;
+use ashpd::enumflags2::BitFlags;
+use cosmic::desktop::IconSourceExt;
+use cosmic::iced::{
+    self,
+    keyboard::{Key, key::Named},
+    window,
+};
+use fde::IconSource;
+
+use cosmic::iced_runtime::platform_specific::wayland::layer_surface::SctkLayerSurfaceSettings;
+use cosmic::iced_winit::commands::layer_surface::{
+    KeyboardInteractivity, Layer, destroy_layer_surface, get_layer_surface,
+};
+use cosmic::widget::autosize;
+use cosmic::{theme, widget};
+use cosmic_client_toolkit::sctk::output::OutputInfo;
+use cosmic_client_toolkit::toplevel_info::ToplevelInfo;
+use freedesktop_desktop_entry as fde;
+use freedesktop_desktop_entry::{DesktopEntry, get_languages_from_env, unicase::Ascii};
+use std::mem;
+use std::sync::LazyLock;
+use tokio::sync::mpsc;
+use wayland_client::protocol::wl_output::WlOutput;
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1;
+use zbus::zvariant;
+
+pub static REMOTEDESKTOP_ID: LazyLock<window::Id> = LazyLock::new(window::Id::unique);
+pub static REMOTEDESKTOP_WIDGET_ID: LazyLock<widget::Id> =
+    LazyLock::new(|| widget::Id::new("remote-desktop".to_string()));
+
+pub async fn hide_remote_desktop_prompt(
+    subscription_tx: &mpsc::Sender<crate::subscription::Event>,
+    session_handle: &zvariant::ObjectPath<'_>,
+) {
+    let _ = subscription_tx
+        .send(crate::subscription::Event::CancelRemoteDesktop(
+            session_handle.to_owned(),
+        ))
+        .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn show_remote_desktop_prompt(
+    subscription_tx: &mpsc::Sender<crate::subscription::Event>,
+    session_handle: &zvariant::ObjectPath<'_>,
+    app_id: String,
+    device_types: u32,
+    include_screencast: bool,
+    multiple: bool,
+    source_types: BitFlags<SourceType>,
+    wayland_helper: &WaylandHelper,
+) -> Option<CaptureSources> {
+    let locales = get_languages_from_env();
+    let desktop_entries = load_desktop_entries(&locales).await;
+
+    let toplevels = wayland_helper
+        .toplevels()
+        .into_iter()
+        .map(|info| {
+            let icon = get_desktop_entry(&desktop_entries, &info.app_id)
+                .and_then(|x| Some(x.icon()?.to_string()));
+            (info, icon)
+        })
+        .collect();
+
+    let mut outputs = Vec::new();
+    for output in wayland_helper.outputs() {
+        let Some(info) = wayland_helper.output_info(&output) else {
+            continue;
+        };
+        let source = CaptureSource::Output(output.clone());
+        let image = wayland_helper
+            .capture_source_shm(source, false)
+            .await
+            .and_then(|image| image.image_transformed().ok())
+            .map(|image| {
+                widget::image::Handle::from_rgba(image.width(), image.height(), image.into_vec())
+            });
+        outputs.push((output, info, image));
+    }
+
+    let app_name = get_desktop_entry(&desktop_entries, &app_id)
+        .and_then(|x| Some(x.name(&locales)?.into_owned()));
+
+    let (tx, mut rx) = mpsc::channel(1);
+    let args = Args {
+        session_handle: session_handle.to_owned(),
+        outputs,
+        toplevels,
+        device_types,
+        include_screencast,
+        multiple,
+        source_types,
+        app_name,
+        tx,
+        capture_sources: Default::default(),
+    };
+    if subscription_tx
+        .send(crate::subscription::Event::RemoteDesktop(args))
+        .await
+        .is_err()
+    {
+        log::error!("Failed to send RemoteDesktop event to subscription handler");
+        return None;
+    }
+    rx.recv().await.unwrap_or(None)
+}
+
+async fn load_desktop_entries(locales: &[String]) -> Vec<DesktopEntry> {
+    let mut entries = Vec::new();
+    for p in fde::Iter::new(fde::default_paths()) {
+        if let Ok(data) = tokio::fs::read_to_string(&p).await
+            && let Ok(entry) = DesktopEntry::from_str(&p, &data, Some(locales))
+        {
+            entries.push(entry.to_owned());
+        }
+    }
+    entries
+}
+
+fn get_desktop_entry<'a>(entries: &'a [DesktopEntry], id: &str) -> Option<&'a DesktopEntry> {
+    fde::find_app_by_id(entries, Ascii::new(id))
+}
+
+fn create_dialog() -> cosmic::Task<crate::app::Msg> {
+    get_layer_surface(SctkLayerSurfaceSettings {
+        id: *REMOTEDESKTOP_ID,
+        keyboard_interactivity: KeyboardInteractivity::Exclusive,
+        namespace: "remote-desktop".into(),
+        layer: Layer::Overlay,
+        size: None,
+        ..Default::default()
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Tab {
+    Outputs,
+    Windows,
+}
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    session_handle: zvariant::ObjectPath<'static>,
+    device_types: u32,
+    include_screencast: bool,
+    multiple: bool,
+    source_types: BitFlags<SourceType>,
+    outputs: Vec<(WlOutput, OutputInfo, Option<widget::image::Handle>)>,
+    toplevels: Vec<(ToplevelInfo, Option<String>)>,
+    app_name: Option<String>,
+    tx: mpsc::Sender<Option<CaptureSources>>,
+    capture_sources: CaptureSources,
+}
+
+impl Args {
+    fn send_response(self, response: Option<CaptureSources>) {
+        tokio::spawn(async move {
+            if let Err(err) = self.tx.send(response).await {
+                log::error!("Failed to send remote desktop event: {}", err);
+            }
+        });
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CaptureSources {
+    pub outputs: Vec<WlOutput>,
+    pub toplevels: Vec<ExtForeignToplevelHandleV1>,
+}
+
+impl CaptureSources {
+    pub fn is_empty(&self) -> bool {
+        self.outputs.is_empty() && self.toplevels.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.outputs.clear();
+        self.toplevels.clear();
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Msg {
+    ActivateTab(widget::segmented_button::Entity),
+    SelectOutput(WlOutput),
+    SelectToplevel(ExtForeignToplevelHandleV1),
+    Allow,
+    Deny,
+}
+
+fn active_tab(portal: &CosmicPortal) -> Tab {
+    *portal
+        .remotedesktop_tab_model
+        .active_data::<Tab>()
+        .unwrap()
+}
+
+pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::app::Msg> {
+    let Some(args) = portal.remotedesktop_args.as_mut() else {
+        return cosmic::Task::none();
+    };
+
+    match msg {
+        Msg::ActivateTab(tab) => {
+            portal.remotedesktop_tab_model.activate(tab);
+        }
+        Msg::SelectOutput(output) => {
+            if let Some(idx) = args
+                .capture_sources
+                .outputs
+                .iter()
+                .position(|x| x == &output)
+            {
+                args.capture_sources.outputs.remove(idx);
+            } else {
+                if !args.multiple && !args.capture_sources.is_empty() {
+                    args.capture_sources.clear();
+                }
+                args.capture_sources.outputs.push(output);
+            }
+        }
+        Msg::SelectToplevel(toplevel) => {
+            if let Some(idx) = args
+                .capture_sources
+                .toplevels
+                .iter()
+                .position(|t| t == &toplevel)
+            {
+                args.capture_sources.toplevels.remove(idx);
+            } else {
+                if !args.multiple && !args.capture_sources.is_empty() {
+                    args.capture_sources.clear();
+                }
+                args.capture_sources.toplevels.push(toplevel);
+            }
+        }
+        Msg::Allow => {
+            if let Some(mut args) = portal.remotedesktop_args.take() {
+                let response = mem::take(&mut args.capture_sources);
+                args.send_response(Some(response));
+                return destroy_layer_surface(*REMOTEDESKTOP_ID);
+            }
+        }
+        Msg::Deny => {
+            if let Some(args) = portal.remotedesktop_args.take() {
+                args.send_response(None);
+                return destroy_layer_surface(*REMOTEDESKTOP_ID);
+            }
+        }
+    }
+    cosmic::Task::none()
+}
+
+pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Task<crate::app::Msg> {
+    let command = if let Some(args) = portal.remotedesktop_args.take() {
+        args.send_response(None);
+        cosmic::Task::none()
+    } else {
+        create_dialog()
+    };
+
+    portal.remotedesktop_tab_model.clear();
+    if args.include_screencast {
+        if args.source_types.contains(SourceType::Monitor) {
+            portal
+                .remotedesktop_tab_model
+                .insert()
+                .data(Tab::Outputs)
+                .text(fl!("output"));
+        }
+        if args.source_types.contains(SourceType::Window) {
+            portal
+                .remotedesktop_tab_model
+                .insert()
+                .data(Tab::Windows)
+                .text(fl!("window"));
+        }
+        portal.remotedesktop_tab_model.activate_position(0);
+    }
+
+    portal.remotedesktop_args = Some(args);
+
+    command
+}
+
+pub fn cancel(
+    portal: &mut CosmicPortal,
+    session_handle: zvariant::ObjectPath<'static>,
+) -> cosmic::Task<crate::app::Msg> {
+    if portal
+        .remotedesktop_args
+        .as_ref()
+        .is_some_and(|args| args.session_handle == session_handle)
+    {
+        let args = portal.remotedesktop_args.take().unwrap();
+        args.send_response(None);
+        destroy_layer_surface(*REMOTEDESKTOP_ID)
+    } else {
+        cosmic::Task::none()
+    }
+}
+
+fn permission_chips(device_types: u32) -> Vec<cosmic::Element<'static, Msg>> {
+    let mut items = Vec::new();
+    if device_types & 1 != 0 {
+        items.push(device_chip(
+            "input-keyboard-symbolic",
+            fl!("remote-desktop-keyboard"),
+        ));
+    }
+    if device_types & 2 != 0 {
+        items.push(device_chip(
+            "input-mouse-symbolic",
+            fl!("remote-desktop-pointer"),
+        ));
+    }
+    if device_types & 4 != 0 {
+        items.push(device_chip(
+            "input-touchpad-symbolic",
+            fl!("remote-desktop-touchscreen"),
+        ));
+    }
+    items
+}
+
+fn device_chip(icon_name: &'static str, label: String) -> cosmic::Element<'static, Msg> {
+    widget::row::with_children(vec![
+        widget::icon::from_name(icon_name).size(16).into(),
+        widget::text::body(label).into(),
+    ])
+    .spacing(4)
+    .align_y(iced::Alignment::Center)
+    .into()
+}
+
+fn output_button_appearance(
+    theme: &cosmic::Theme,
+    is_active: bool,
+    hovered: bool,
+) -> widget::button::Style {
+    let cosmic = theme.cosmic();
+    let mut appearance = widget::button::Style::new();
+    appearance.border_radius = cosmic.corner_radii.radius_s.into();
+    if is_active {
+        appearance.border_width = 2.0;
+        appearance.border_color = cosmic.accent.base.into();
+    }
+    if hovered {
+        appearance.background = Some(iced::Background::Color(cosmic.button.base.into()));
+    }
+    appearance
+}
+
+fn output_button<'a>(
+    label: &'a str,
+    is_selected: bool,
+    image_handle: Option<&'a widget::image::Handle>,
+    msg: Msg,
+) -> cosmic::Element<'a, Msg> {
+    let text = widget::text(label).class(theme::style::Text::Custom(|theme| {
+        let container = theme.current_container();
+        cosmic::iced_core::widget::text::Style {
+            color: Some(container.on.into()),
+        }
+    }));
+    let mut row_children = vec![text.into()];
+    if is_selected {
+        row_children.push(widget::text("\u{2713}").into());
+    }
+    let row = widget::row::with_children(row_children).spacing(12);
+
+    let mut children = Vec::new();
+    if let Some(image_handle) = image_handle {
+        children.push(widget::image::Image::new(image_handle.clone()).into());
+    }
+    children.push(row.into());
+    let column = widget::column::with_children(children).spacing(12);
+
+    widget::button::custom(column)
+        .width(iced::Length::Fill)
+        .padding(8)
+        .selected(is_selected)
+        .class(cosmic::theme::Button::Custom {
+            active: Box::new(move |_focused, theme| {
+                output_button_appearance(theme, is_selected, false)
+            }),
+            disabled: Box::new(|_theme| unreachable!()),
+            hovered: Box::new(move |_focused, theme| {
+                output_button_appearance(theme, is_selected, true)
+            }),
+            pressed: Box::new(move |_focused, theme| {
+                output_button_appearance(theme, is_selected, true)
+            }),
+        })
+        .on_press(msg)
+        .into()
+}
+
+fn toplevel_button(
+    label: &str,
+    is_selected: bool,
+    icon: IconSource,
+    msg: Msg,
+) -> cosmic::Element<'_, Msg> {
+    let text = widget::text(label).class(theme::style::Text::Custom(|theme| {
+        let container = theme.current_container();
+        cosmic::iced_core::widget::text::Style {
+            color: Some(container.on.into()),
+        }
+    }));
+    let button = widget::button::custom(text)
+        .width(iced::Length::Fill)
+        .padding(0)
+        .class(theme::style::Button::Transparent)
+        .selected(is_selected)
+        .on_press(msg);
+    let mut children = Vec::new();
+    children.push(icon.as_cosmic_icon().size(24).into());
+    children.push(button.into());
+    if is_selected {
+        children.push(widget::text("\u{2713}").into());
+    }
+    widget::row::with_children(children).spacing(12).into()
+}
+
+pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
+    let Some(args) = portal.remotedesktop_args.as_ref() else {
+        return widget::horizontal_space()
+            .width(iced::Length::Fixed(1.0))
+            .into();
+    };
+
+    let deny_button = widget::button::standard(fl!("cancel")).on_press(Msg::Deny);
+    let mut allow_button =
+        widget::button::standard(fl!("allow")).class(cosmic::style::Button::Suggested);
+
+    // For remote desktop, allow even without screen selection (input-only mode)
+    if !args.include_screencast || !args.capture_sources.is_empty() {
+        allow_button = allow_button.on_press(Msg::Allow);
+    }
+
+    let unknown = fl!("unknown-application");
+    let app_name = args.app_name.as_deref().unwrap_or(&unknown);
+
+    let mut content_children: Vec<cosmic::Element<'_, Msg>> = Vec::new();
+
+    // Permission summary: description text + device icon chips
+    content_children.push(
+        widget::text(fl!(
+            "remote-desktop-access",
+            "description",
+            app_name = app_name
+        ))
+        .into(),
+    );
+    content_children.push(
+        widget::row::with_children(permission_chips(args.device_types))
+            .spacing(12)
+            .into(),
+    );
+
+    // Screen selection (if screencast is included)
+    if args.include_screencast && portal.remotedesktop_tab_model.iter().next().is_some() {
+        let tabs = widget::tab_bar::horizontal(&portal.remotedesktop_tab_model)
+            .on_activate(Msg::ActivateTab);
+
+        let list: cosmic::Element<_> = match active_tab(portal) {
+            Tab::Outputs => {
+                let mut children = Vec::new();
+                for (output, output_info, image_handle) in &args.outputs {
+                    let label = output_info.name.as_ref().unwrap();
+                    let is_selected = args.capture_sources.outputs.contains(output);
+                    children.push(output_button(
+                        label,
+                        is_selected,
+                        image_handle.as_ref(),
+                        Msg::SelectOutput(output.clone()),
+                    ));
+                }
+                widget::row::with_children(children).spacing(8).into()
+            }
+            Tab::Windows => {
+                let mut list = widget::ListColumn::new();
+                for (toplevel_info, icon) in &args.toplevels {
+                    let icon = IconSource::from_unknown(icon.as_deref().unwrap_or_default());
+                    let label = &toplevel_info.title;
+                    let is_selected = args
+                        .capture_sources
+                        .toplevels
+                        .contains(&toplevel_info.foreign_toplevel);
+                    list = list.add(toplevel_button(
+                        label,
+                        is_selected,
+                        icon,
+                        Msg::SelectToplevel(toplevel_info.foreign_toplevel.clone()),
+                    ));
+                }
+                if args.toplevels.len() > 8 {
+                    widget::container(cosmic::widget::scrollable(list))
+                        .max_height(380.)
+                        .width(iced::Length::Fill)
+                        .into()
+                } else {
+                    list.into()
+                }
+            }
+        };
+
+        content_children.push(tabs.into());
+        content_children.push(list);
+    }
+
+    let control = widget::column::with_children(content_children).spacing(8);
+
+    autosize::autosize(
+        KeyboardWrapper::new(
+            widget::dialog()
+                .title(fl!("remote-desktop-access"))
+                .secondary_action(deny_button)
+                .primary_action(allow_button)
+                .control(control),
+            |key, _| match key {
+                Key::Named(Named::Enter) => Some(Msg::Allow),
+                Key::Named(Named::Escape) => Some(Msg::Deny),
+                _ => None,
+            },
+        ),
+        REMOTEDESKTOP_WIDGET_ID.clone(),
+    )
+    .max_width(572.)
+    .max_height(884.)
+    .min_width(1.)
+    .min_height(1.)
+    .into()
+}

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -130,8 +130,18 @@ pub struct StreamProps {
     position: Option<(i32, i32)>,
     size: (i32, i32),
     source_type: u32,
-    // TODO: Add when remote desktop portal is implemented
     mapping_id: Option<String>,
+}
+
+impl StreamProps {
+    pub fn new(position: Option<(i32, i32)>, size: (i32, i32), source_type: u32) -> Self {
+        Self {
+            position,
+            size,
+            source_type,
+            mapping_id: None,
+        }
+    }
 }
 
 #[derive(zvariant::SerializeDict, zvariant::Type)]


### PR DESCRIPTION
## Summary

Builds on @ids1024's WIP skeleton (`d26d88c`) to implement the full RemoteDesktop portal:

- **Complete session lifecycle:** `CreateSession`, `SelectDevices`, `SelectSources`, `Start`, `ConnectToEIS` with proper session state management
- **Consent dialog UI:** Device type chips (keyboard/pointer/touchscreen) and optional screen/window selection tabs, reusing the ScreenCast dialog patterns
- **EIS socket pair creation:** Unix socket pair with server-side fd forwarded to `com.system76.CosmicComp.RemoteDesktop` via D-Bus, client fd returned to requesting application
- **ScreenCast integration:** Reuses `ScreencastThread` and PipeWire infrastructure for video streams; adds `StreamProps::new()` constructor for shared use
- **Security:** Consent dialog is always shown - restore data is never used to skip consent for RemoteDesktop (input injection is too sensitive)
- **i18n:** English strings for remote desktop dialog added to Fluent file

### Files changed

| File | Change |
|------|--------|
| `src/remote_desktop.rs` | Full implementation replacing WIP stub (~500 lines) |
| `src/remote_desktop_dialog.rs` | New consent dialog UI (~540 lines) |
| `src/app.rs` | RemoteDesktop state fields, message routing, view |
| `src/subscription.rs` | RemoteDesktop event variants, D-Bus registration |
| `src/screencast.rs` | `StreamProps::new()` constructor for reuse |
| `src/main.rs` | Module declaration |
| `Cargo.toml` | Added `reis` dependency |
| `i18n/en/*.ftl` | Dialog strings |

## Test plan

- [ ] Build succeeds with `cargo build`
- [ ] RemoteDesktop portal appears in D-Bus introspection
- [ ] Consent dialog shows when an app requests remote desktop access
- [ ] Device types (keyboard, pointer, touchscreen) display correctly
- [ ] Screen/window selection works when screencast sources requested
- [ ] EIS socket pair is created and forwarded to compositor
- [ ] Denying consent returns `Cancelled` response
- [ ] Session cleanup works on close

🤖 Generated with [Claude Code](https://claude.com/claude-code)