### PR TITLE
screencast: Handle `stopped` event from server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7771,9 +7771,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -7785,9 +7785,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix 1.1.4",
@@ -7885,9 +7885,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml 0.39.2",
@@ -7909,9 +7909,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ spa_sys = { package = "libspa-sys", git = "https://gitlab.freedesktop.org/pipewi
 pipewire-sys = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
 tempfile = "3.23.0"
 tokio = { version = "1.47.1", features = ["macros", "net", "rt", "sync"] }
-wayland-client = { version = "0.31.11" }
+wayland-client = { version = "0.31.14" }
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"

--- a/src/screencast_thread.rs
+++ b/src/screencast_thread.rs
@@ -72,8 +72,14 @@ impl ScreencastThread {
     ) -> anyhow::Result<Self> {
         let (tx, rx) = oneshot::channel();
         let (thread_stop_tx, thread_stop_rx) = pipewire::channel::channel::<()>();
+        let thread_stop_tx_clone = thread_stop_tx.clone();
         std::thread::spawn(move || {
-            match start_stream(wayland_helper, capture_source, overlay_cursor) {
+            match start_stream(
+                wayland_helper,
+                capture_source,
+                overlay_cursor,
+                thread_stop_tx_clone,
+            ) {
                 Ok((loop_, _stream, _listener, _context, node_id_rx)) => {
                     tx.send(Ok(node_id_rx)).unwrap();
                     let weak_loop = loop_.downgrade();
@@ -115,6 +121,7 @@ struct StreamData {
     formats: Formats,
     node_id_tx: Option<oneshot::Sender<Result<u32, anyhow::Error>>>,
     buffer_damage: HashMap<wl_buffer::WlBuffer, Vec<Rect>>,
+    thread_stop_tx: pipewire::channel::Sender<()>,
 }
 
 impl StreamData {
@@ -427,6 +434,11 @@ impl StreamData {
     }
 
     fn process(&mut self, stream: &Stream) {
+        if self.session.is_stopped() {
+            let _ = self.thread_stop_tx.send(());
+            // TODO: Causes segfault
+            // let _ = stream.disconnect();
+        }
         let buffer = unsafe { stream.dequeue_raw_buffer() };
         if !buffer.is_null() {
             let wl_buffer = unsafe { &*((*buffer).user_data as *const wl_buffer::WlBuffer) };
@@ -483,6 +495,7 @@ fn start_stream(
     wayland_helper: WaylandHelper,
     capture_source: CaptureSource,
     overlay_cursor: bool,
+    thread_stop_tx: pipewire::channel::Sender<()>,
 ) -> anyhow::Result<(
     pipewire::main_loop::MainLoopRc,
     pipewire::stream::StreamRc,
@@ -538,6 +551,7 @@ fn start_stream(
         modifier: None,
         node_id_tx: Some(node_id_tx),
         buffer_damage: HashMap::new(),
+        thread_stop_tx,
     };
 
     let listener = stream

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -232,6 +232,10 @@ impl Session {
             .await
             .unwrap_or(Err(WEnum::Value(FailureReason::Stopped)))
     }
+
+    pub fn is_stopped(&self) -> bool {
+        self.0.state.lock().unwrap().stopped
+    }
 }
 
 impl WaylandHelper {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -225,7 +225,12 @@ impl Session {
         self.0.wayland_helper.inner.conn.flush().unwrap();
 
         // TODO: wait for server to release buffer?
-        receiver.await.unwrap()
+        // Assume stopped if frame is dropped without `ready` or `failed`
+        // - This can happen if the session object has already been destroyed
+        //   when the frame is created.
+        receiver
+            .await
+            .unwrap_or(Err(WEnum::Value(FailureReason::Stopped)))
     }
 }
 


### PR DESCRIPTION
The screencast thread should be terminated and the pipewire stream disconnected if the capture stops (for instance if a toplevel or output being captured no longer exists).

It looks like there are two issues related to stopped streams:
* `stopped` is not (always?) sent when it should be for outputs; but is sent for toplevels
* When a frame errors due to being stopped, a panic occurs in wayland-backend for some reason...

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

