### PR TITLE
fix: update accent color when light/dark mode switched

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -345,10 +345,6 @@ impl cosmic::Application for CosmicPortal {
         let old = self.core.system_theme().cosmic();
         let mut msgs = Vec::with_capacity(3);
 
-        if old.is_dark != new_theme.is_dark {
-            return Task::none();
-        }
-
         if old.accent_color() != new_theme.accent_color() {
             msgs.push(subscription::Event::Accent(new_theme.accent_color()));
         }


### PR DESCRIPTION
- Fixes the accent color not changing when switching between light and dark mode. 
- Fixes https://github.com/pop-os/libcosmic/issues/1258.

Testing instructions:
1. Build and install `make && sudo make install`
2. In COSMIC Settings, change the accent colors so they're easily distinguishable. E.g. set the light mode accent color to purple and the dark mode accent color to green.
3. Open Firefox and observe the urls' text color (dark green in the following screenshot) while switching between light and dark mode.
4. Observe that the text color (= accent color) doesn't change between light and dark mode without this PR.

<img width="918" height="656" alt="image" src="https://github.com/user-attachments/assets/c0eea9f9-a2fb-4b4c-8a7f-39862d6a2b3e" />

After this PR:
- Accent color correctly changes between light and dark mode.
- However, when you switch, Firefox resets back to its default blue accent color.
  Your real accent color only shows after you restart Firefox.
  This is still better than before and it has proper text contrast.

***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

