### PR TITLE
Add screenshot annotation mode

### DIFF
--- a/i18n/en/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/en/xdg_desktop_portal_cosmic.ftl
@@ -1,6 +1,9 @@
 allow = Allow
 cancel = Cancel
 capture = Capture
+annotation-arrow = Arrow
+annotation-rectangle = Rectangle
+undo = Undo
 share = Share
 save-to = Save to
     .clipboard = { save-to } Clipboard

--- a/i18n/tr/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/tr/xdg_desktop_portal_cosmic.ftl
@@ -1,6 +1,9 @@
 allow = İzin ver
 cancel = Vazgeç
 capture = Yakala
+annotation-arrow = Ok
+annotation-rectangle = Dikdörtgen
+undo = Geri al
 share = Paylaş
 save-to = Kaydet
     .clipboard = { save-to } Panoya

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -13,7 +13,7 @@ use cosmic::iced_winit::commands::layer_surface::{destroy_layer_surface, get_lay
 use cosmic::widget::space;
 use cosmic_client_toolkit::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
 use futures::stream::{FuturesUnordered, StreamExt};
-use image::RgbaImage;
+use image::{Rgba, RgbaImage};
 use rustix::fd::AsFd;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
@@ -40,14 +40,18 @@ pub struct ScreenshotImage {
 }
 
 impl ScreenshotImage {
-    fn new<T: AsFd>(img: ShmImage<T>) -> anyhow::Result<Self> {
-        let rgba = img.image_transformed()?;
+    fn from_rgba(rgba: RgbaImage) -> Self {
         let handle = cosmic::widget::image::Handle::from_rgba(
             rgba.width(),
             rgba.height(),
             rgba.clone().into_vec(),
         );
-        Ok(Self { rgba, handle })
+        Self { rgba, handle }
+    }
+
+    fn new<T: AsFd>(img: ShmImage<T>) -> anyhow::Result<Self> {
+        let rgba = img.image_transformed()?;
+        Ok(Self::from_rgba(rgba))
     }
 
     pub fn width(&self) -> u32 {
@@ -157,6 +161,72 @@ impl Rect {
 pub struct RectDimension {
     width: NonZeroU32,
     height: NonZeroU32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnnotationTool {
+    Rectangle,
+    Arrow,
+}
+
+impl Default for AnnotationTool {
+    fn default() -> Self {
+        Self::Rectangle
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AnnotationPoint {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl AnnotationPoint {
+    pub fn distance(self, other: Self) -> f32 {
+        (self.x - other.x).hypot(self.y - other.y)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AnnotationShape {
+    Rectangle {
+        start: AnnotationPoint,
+        end: AnnotationPoint,
+    },
+    Arrow {
+        start: AnnotationPoint,
+        end: AnnotationPoint,
+    },
+}
+
+impl AnnotationShape {
+    pub fn new(tool: AnnotationTool, start: AnnotationPoint, end: AnnotationPoint) -> Self {
+        match tool {
+            AnnotationTool::Rectangle => Self::Rectangle { start, end },
+            AnnotationTool::Arrow => Self::Arrow { start, end },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AnnotationState {
+    pub image: ScreenshotImage,
+    pub output_name: String,
+    pub tool: AnnotationTool,
+    pub annotations: Vec<AnnotationShape>,
+    pub draft: Option<AnnotationShape>,
+}
+
+impl AnnotationState {
+    fn new(image: RgbaImage, output_name: String) -> Self {
+        Self {
+            image: ScreenshotImage::from_rgba(image),
+            output_name,
+            tool: AnnotationTool::default(),
+            annotations: Vec::new(),
+            draft: None,
+        }
+    }
 }
 
 pub struct Screenshot {
@@ -379,6 +449,10 @@ pub enum Msg {
     CaptureWithLocation(ImageSaveLocation),
     Cancel,
     Choice(Choice),
+    AnnotationDraft(Option<AnnotationShape>),
+    AnnotationCommit(AnnotationShape),
+    AnnotationTool(AnnotationTool),
+    AnnotationUndo,
     OutputChanged(WlOutput),
     WindowChosen(String, usize),
     Location(usize),
@@ -425,6 +499,7 @@ pub struct Args {
     pub choice: Choice,
     pub location: ImageSaveLocation,
     pub action: Action,
+    pub annotation: Option<AnnotationState>,
 }
 
 struct Output {
@@ -537,6 +612,7 @@ impl Screenshot {
                     location: config.save_location,
                     // TODO cover all outputs at start of rectangle?
                     choice,
+                    annotation: None,
                     // will be updated
                 }))
                 .await
@@ -590,6 +666,60 @@ pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<'_,
     let Some(args) = portal.screenshot_args.as_ref() else {
         return space::horizontal().width(Length::Fixed(1.0)).into();
     };
+    if let Some(annotation) = &args.annotation {
+        if annotation.output_name != output.name.as_str() {
+            return space::horizontal().width(Length::Fixed(1.0)).into();
+        }
+
+        let theme = portal.core.system_theme().cosmic();
+        return KeyboardWrapper::new(
+            crate::widget::screenshot::ScreenshotSelection::new_annotation(
+                annotation,
+                Msg::Capture,
+                Msg::Cancel,
+                Msg::AnnotationTool,
+                Msg::AnnotationUndo,
+                Msg::AnnotationDraft,
+                Msg::AnnotationCommit,
+                &portal.location_options,
+                args.location as usize,
+                Msg::Location,
+                theme.spacing,
+            ),
+            |key, modifiers| {
+                if modifiers.control() {
+                    match key {
+                        Key::Named(Named::Copy) => {
+                            return Some(Msg::CaptureWithLocation(ImageSaveLocation::Clipboard));
+                        }
+                        Key::Named(Named::Save) => {
+                            return Some(Msg::CaptureWithLocation(ImageSaveLocation::Pictures));
+                        }
+                        Key::Character(ref value) => {
+                            let value = value.as_str();
+                            if value.eq_ignore_ascii_case("c") {
+                                return Some(Msg::CaptureWithLocation(
+                                    ImageSaveLocation::Clipboard,
+                                ));
+                            } else if value.eq_ignore_ascii_case("s") {
+                                return Some(Msg::CaptureWithLocation(ImageSaveLocation::Pictures));
+                            } else if value.eq_ignore_ascii_case("z") {
+                                return Some(Msg::AnnotationUndo);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                match key {
+                    Key::Named(Named::Enter) => Some(Msg::Capture),
+                    Key::Named(Named::Escape) => Some(Msg::Cancel),
+                    _ => None,
+                }
+            },
+        )
+        .into();
+    }
 
     let Some(img) = args.output_images.get(&output.name) else {
         return space::horizontal().width(Length::Fixed(1.0)).into();
@@ -647,121 +777,15 @@ pub(crate) fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<'_,
 pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::app::Msg> {
     match msg {
         Msg::Capture => {
-            let mut cmds: Vec<cosmic::Task<crate::app::Msg>> = portal
-                .outputs
-                .iter()
-                .map(|o| destroy_layer_surface(o.id))
-                .collect();
-            let Some(args) = portal.screenshot_args.take() else {
-                log::error!("Failed to find screenshot Args for Capture message.");
-                return cosmic::Task::batch(cmds);
-            };
-            let outputs = portal.outputs.clone();
-            let Args {
-                tx,
-                choice,
-                output_images: mut images,
-                location,
-                ..
-            } = args;
-
-            let mut success = true;
-            let image_path = Screenshot::get_img_path(location);
-
-            match choice {
-                Choice::Output(name) => {
-                    if let Some(img) = images.remove(&name) {
-                        if let Ok(buffer) = Screenshot::save_rgba(&img.rgba, image_path.as_deref())
-                            .inspect_err(|err| {
-                                log::error!("Failed to capture screenshot: {:?}", err);
-                                success = false;
-                            })
-                        {
-                            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
-                        }
-                    } else {
-                        log::error!("Failed to find output {}", name);
-                        success = false;
-                    }
-                }
-                Choice::Rectangle(r, s) => {
-                    if let Some(RectDimension { width, height }) = r.dimensions() {
-                        // Construct Rgba image with size of rect
-                        // then overlay the part of each image that intersects with the rect
-                        //let mut img = RgbaImage::new(width.get(), height.get());
-
-                        let frames = images
-                            .into_iter()
-                            .filter_map(|(name, raw_img)| {
-                                let output = outputs.iter().find(|o| o.name == name)?;
-                                let pos = output.logical_pos;
-                                let output_rect = Rect {
-                                    left: pos.0,
-                                    top: pos.1,
-                                    right: pos.0 + output.logical_size.0 as i32,
-                                    bottom: pos.1 + output.logical_size.1 as i32,
-                                };
-
-                                let intersect = r.intersect(output_rect)?;
-
-                                Some((raw_img.rgba, output_rect))
-                            })
-                            .collect::<Vec<_>>();
-                        let img = combined_image(r, frames);
-
-                        if let Ok(buffer) = Screenshot::save_rgba(&img, image_path.as_deref())
-                            .inspect_err(|err| {
-                                log::error!("Failed to capture screenshot: {:?}", err);
-                                success = false;
-                            })
-                        {
-                            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
-                        }
-                    } else {
-                        success = false;
-                    }
-                }
-                Choice::Window(output, Some(window_i)) => {
-                    if let Some(img) = args
-                        .toplevel_images
-                        .get(&output)
-                        .and_then(|imgs| imgs.get(window_i))
-                    {
-                        if let Ok(buffer) = Screenshot::save_rgba(&img.rgba, image_path.as_deref())
-                            .inspect_err(|err| {
-                                log::error!("Failed to capture screenshot: {:?}", err);
-                                success = false;
-                            })
-                        {
-                            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
-                        }
-                    } else {
-                        success = false;
-                    }
-                }
-                _ => {
-                    success = false;
-                }
-            }
-
-            let response = if success && image_path.is_some() {
-                PortalResponse::Success(ScreenshotResult {
-                    uri: format!("file:///{}", image_path.unwrap().display()),
-                })
-            } else if success && image_path.is_none() {
-                PortalResponse::Success(ScreenshotResult {
-                    uri: "clipboard:///".to_string(),
-                })
+            if portal
+                .screenshot_args
+                .as_ref()
+                .is_some_and(|args| args.annotation.is_none())
+            {
+                start_annotation(portal)
             } else {
-                PortalResponse::Other
-            };
-
-            tokio::spawn(async move {
-                if let Err(err) = tx.send(response).await {
-                    log::error!("Failed to send screenshot event");
-                }
-            });
-            cosmic::Task::batch(cmds)
+                finish_capture(portal)
+            }
         }
         Msg::CaptureWithLocation(location) => {
             if let Some(args) = portal.screenshot_args.as_mut() {
@@ -786,6 +810,49 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
             });
 
             cosmic::Task::batch(cmds)
+        }
+        Msg::AnnotationDraft(draft) => {
+            if let Some(annotation) = portal
+                .screenshot_args
+                .as_mut()
+                .and_then(|args| args.annotation.as_mut())
+            {
+                annotation.draft = draft;
+            }
+            cosmic::Task::none()
+        }
+        Msg::AnnotationCommit(shape) => {
+            if let Some(annotation) = portal
+                .screenshot_args
+                .as_mut()
+                .and_then(|args| args.annotation.as_mut())
+            {
+                annotation.annotations.push(shape);
+                annotation.draft = None;
+            }
+            cosmic::Task::none()
+        }
+        Msg::AnnotationTool(tool) => {
+            if let Some(annotation) = portal
+                .screenshot_args
+                .as_mut()
+                .and_then(|args| args.annotation.as_mut())
+            {
+                annotation.tool = tool;
+                annotation.draft = None;
+            }
+            cosmic::Task::none()
+        }
+        Msg::AnnotationUndo => {
+            if let Some(annotation) = portal
+                .screenshot_args
+                .as_mut()
+                .and_then(|args| args.annotation.as_mut())
+            {
+                annotation.annotations.pop();
+                annotation.draft = None;
+            }
+            cosmic::Task::none()
         }
         Msg::Choice(c) => {
             let choice = (&c).into();
@@ -878,6 +945,253 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
     }
 }
 
+fn start_annotation(portal: &mut CosmicPortal) -> cosmic::Task<crate::app::Msg> {
+    let Some(args) = portal.screenshot_args.as_mut() else {
+        log::error!("Failed to find screenshot Args for annotation.");
+        return cosmic::Task::none();
+    };
+
+    match selected_image(
+        &args.choice,
+        &args.output_images,
+        &args.toplevel_images,
+        &portal.outputs,
+    ) {
+        Some((image, output_name)) => {
+            args.annotation = Some(AnnotationState::new(image, output_name));
+        }
+        None => {
+            log::error!("Failed to prepare screenshot annotation image.");
+        }
+    }
+
+    cosmic::Task::none()
+}
+
+fn finish_capture(portal: &mut CosmicPortal) -> cosmic::Task<crate::app::Msg> {
+    let mut cmds: Vec<cosmic::Task<crate::app::Msg>> = portal
+        .outputs
+        .iter()
+        .map(|o| destroy_layer_surface(o.id))
+        .collect();
+    let Some(args) = portal.screenshot_args.take() else {
+        log::error!("Failed to find screenshot Args for Capture message.");
+        return cosmic::Task::batch(cmds);
+    };
+    let outputs = portal.outputs.clone();
+    let image = args
+        .annotation
+        .as_ref()
+        .map(render_annotations)
+        .or_else(|| {
+            selected_image(
+                &args.choice,
+                &args.output_images,
+                &args.toplevel_images,
+                &outputs,
+            )
+            .map(|(image, _)| image)
+        });
+
+    let Args { tx, location, .. } = args;
+    let image_path = Screenshot::get_img_path(location);
+    let mut success = true;
+
+    if let Some(image) = image {
+        if let Ok(buffer) =
+            Screenshot::save_rgba(&image, image_path.as_deref()).inspect_err(|err| {
+                log::error!("Failed to capture screenshot: {:?}", err);
+                success = false;
+            })
+        {
+            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
+        }
+    } else {
+        success = false;
+    }
+
+    let response = if success {
+        match image_path {
+            Some(image_path) => PortalResponse::Success(ScreenshotResult {
+                uri: format!("file:///{}", image_path.display()),
+            }),
+            None => PortalResponse::Success(ScreenshotResult {
+                uri: "clipboard:///".to_string(),
+            }),
+        }
+    } else {
+        PortalResponse::Other
+    };
+
+    tokio::spawn(async move {
+        if let Err(err) = tx.send(response).await {
+            log::error!("Failed to send screenshot event: {err}");
+        }
+    });
+    cosmic::Task::batch(cmds)
+}
+
+fn selected_image(
+    choice: &Choice,
+    images: &HashMap<String, ScreenshotImage>,
+    toplevel_images: &HashMap<String, Vec<ScreenshotImage>>,
+    outputs: &[OutputState],
+) -> Option<(RgbaImage, String)> {
+    match choice {
+        Choice::Output(name) => images.get(name).map(|img| (img.rgba.clone(), name.clone())),
+        Choice::Rectangle(r, _) => {
+            r.dimensions()?;
+            let frames = images
+                .iter()
+                .filter_map(|(name, raw_img)| {
+                    let output = outputs.iter().find(|o| o.name == *name)?;
+                    let pos = output.logical_pos;
+                    let output_rect = Rect {
+                        left: pos.0,
+                        top: pos.1,
+                        right: pos.0 + output.logical_size.0 as i32,
+                        bottom: pos.1 + output.logical_size.1 as i32,
+                    };
+
+                    r.intersect(output_rect)?;
+
+                    Some((raw_img.rgba.clone(), output_rect))
+                })
+                .collect::<Vec<_>>();
+            let output_name = output_for_rect(*r, outputs)?;
+            Some((combined_image(*r, frames), output_name))
+        }
+        Choice::Window(output, Some(window_i)) => toplevel_images
+            .get(output)
+            .and_then(|imgs| imgs.get(*window_i))
+            .map(|img| (img.rgba.clone(), output.clone())),
+        _ => None,
+    }
+}
+
+fn output_for_rect(rect: Rect, outputs: &[OutputState]) -> Option<String> {
+    let center_x = rect.left + rect.width() / 2;
+    let center_y = rect.top + rect.height() / 2;
+
+    outputs
+        .iter()
+        .find(|output| {
+            let left = output.logical_pos.0;
+            let top = output.logical_pos.1;
+            let right = left + output.logical_size.0 as i32;
+            let bottom = top + output.logical_size.1 as i32;
+            center_x >= left && center_x <= right && center_y >= top && center_y <= bottom
+        })
+        .or_else(|| outputs.first())
+        .map(|output| output.name.clone())
+}
+
+fn render_annotations(annotation: &AnnotationState) -> RgbaImage {
+    let mut image = annotation.image.rgba.clone();
+    let color = Rgba([255, 80, 64, 255]);
+    let thickness = ((image.width().max(image.height()) as f32 / 360.0).round() as i32).max(3);
+
+    for shape in &annotation.annotations {
+        match *shape {
+            AnnotationShape::Rectangle { start, end } => {
+                let start = image_point(start, &image);
+                let end = image_point(end, &image);
+                draw_rect(&mut image, start, end, color, thickness);
+            }
+            AnnotationShape::Arrow { start, end } => {
+                let start = image_point(start, &image);
+                let end = image_point(end, &image);
+                draw_arrow(&mut image, start, end, color, thickness);
+            }
+        }
+    }
+
+    image
+}
+
+fn image_point(point: AnnotationPoint, image: &RgbaImage) -> (i32, i32) {
+    (
+        (point.x.clamp(0.0, 1.0) * image.width().saturating_sub(1) as f32).round() as i32,
+        (point.y.clamp(0.0, 1.0) * image.height().saturating_sub(1) as f32).round() as i32,
+    )
+}
+
+fn draw_rect(
+    image: &mut RgbaImage,
+    start: (i32, i32),
+    end: (i32, i32),
+    color: Rgba<u8>,
+    thickness: i32,
+) {
+    let left = start.0.min(end.0);
+    let right = start.0.max(end.0);
+    let top = start.1.min(end.1);
+    let bottom = start.1.max(end.1);
+
+    draw_line(image, (left, top), (right, top), color, thickness);
+    draw_line(image, (right, top), (right, bottom), color, thickness);
+    draw_line(image, (right, bottom), (left, bottom), color, thickness);
+    draw_line(image, (left, bottom), (left, top), color, thickness);
+}
+
+fn draw_arrow(
+    image: &mut RgbaImage,
+    start: (i32, i32),
+    end: (i32, i32),
+    color: Rgba<u8>,
+    thickness: i32,
+) {
+    draw_line(image, start, end, color, thickness);
+
+    let dx = (end.0 - start.0) as f32;
+    let dy = (end.1 - start.1) as f32;
+    let angle = dy.atan2(dx);
+    let head_len = (thickness as f32 * 7.0).max(18.0);
+    let spread = 0.55;
+
+    for head_angle in [
+        angle + std::f32::consts::PI - spread,
+        angle + std::f32::consts::PI + spread,
+    ] {
+        let head = (
+            (end.0 as f32 + head_len * head_angle.cos()).round() as i32,
+            (end.1 as f32 + head_len * head_angle.sin()).round() as i32,
+        );
+        draw_line(image, end, head, color, thickness);
+    }
+}
+
+fn draw_line(
+    image: &mut RgbaImage,
+    start: (i32, i32),
+    end: (i32, i32),
+    color: Rgba<u8>,
+    thickness: i32,
+) {
+    let dx = end.0 - start.0;
+    let dy = end.1 - start.1;
+    let steps = dx.abs().max(dy.abs()).max(1);
+
+    for step in 0..=steps {
+        let t = step as f32 / steps as f32;
+        let x = (start.0 as f32 + dx as f32 * t).round() as i32;
+        let y = (start.1 as f32 + dy as f32 * t).round() as i32;
+        draw_dot(image, x, y, color, thickness);
+    }
+}
+
+fn draw_dot(image: &mut RgbaImage, x: i32, y: i32, color: Rgba<u8>, thickness: i32) {
+    let radius = thickness / 2;
+    for yy in y - radius..=y + radius {
+        for xx in x - radius..=x + radius {
+            if xx < 0 || yy < 0 || xx >= image.width() as i32 || yy >= image.height() as i32 {
+                continue;
+            }
+            image.put_pixel(xx as u32, yy as u32, color);
+        }
+    }
+}
+
 pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Task<crate::app::Msg> {
     let Args {
         handle,
@@ -890,6 +1204,7 @@ pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Task<crate:
         action,
         location,
         toplevel_images,
+        annotation: _,
     } = &args;
 
     if portal.outputs.len() != images.len() {

--- a/src/widget/annotation_canvas.rs
+++ b/src/widget/annotation_canvas.rs
@@ -1,0 +1,295 @@
+use cosmic::{
+    iced::mouse,
+    iced_core::{
+        self, Background, Border, Color, Length, Point, Rectangle, Renderer, Shadow, Size,
+        layout::Node,
+        renderer::Quad,
+        widget::{
+            Tree,
+            tree::{self, State},
+        },
+    },
+    widget::Widget,
+};
+
+use crate::screenshot::{AnnotationPoint, AnnotationShape, AnnotationTool};
+
+const HANDLE_SIZE: f32 = 8.0;
+const LINE_STEP: f32 = 3.0;
+
+pub struct AnnotationCanvas<Msg> {
+    annotations: Vec<AnnotationShape>,
+    draft: Option<AnnotationShape>,
+    tool: AnnotationTool,
+    on_draft: Box<dyn Fn(Option<AnnotationShape>) -> Msg>,
+    on_commit: Box<dyn Fn(AnnotationShape) -> Msg>,
+}
+
+impl<Msg> AnnotationCanvas<Msg> {
+    pub fn new(
+        annotations: Vec<AnnotationShape>,
+        draft: Option<AnnotationShape>,
+        tool: AnnotationTool,
+        on_draft: impl Fn(Option<AnnotationShape>) -> Msg + 'static,
+        on_commit: impl Fn(AnnotationShape) -> Msg + 'static,
+    ) -> Self {
+        Self {
+            annotations,
+            draft,
+            tool,
+            on_draft: Box::new(on_draft),
+            on_commit: Box::new(on_commit),
+        }
+    }
+
+    fn point_at(cursor: mouse::Cursor, bounds: Rectangle) -> Option<AnnotationPoint> {
+        let position = cursor.position()?;
+        if !bounds.contains(position) {
+            return None;
+        }
+
+        Some(AnnotationPoint {
+            x: ((position.x - bounds.x) / bounds.width).clamp(0.0, 1.0),
+            y: ((position.y - bounds.y) / bounds.height).clamp(0.0, 1.0),
+        })
+    }
+}
+
+impl<Msg: Clone + 'static> Widget<Msg, cosmic::Theme, cosmic::Renderer> for AnnotationCanvas<Msg> {
+    fn size(&self) -> Size<Length> {
+        Size::new(Length::Fill, Length::Fill)
+    }
+
+    fn state(&self) -> iced_core::widget::tree::State {
+        State::new(CanvasState::default())
+    }
+
+    fn tag(&self) -> iced_core::widget::tree::Tag {
+        tree::Tag::of::<CanvasState>()
+    }
+
+    fn layout(
+        &mut self,
+        _tree: &mut Tree,
+        _renderer: &cosmic::Renderer,
+        limits: &iced_core::layout::Limits,
+    ) -> Node {
+        Node::new(limits.width(Length::Fill).height(Length::Fill).resolve(
+            Length::Fill,
+            Length::Fill,
+            Size::ZERO,
+        ))
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &Tree,
+        layout: iced_core::Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &cosmic::Renderer,
+    ) -> mouse::Interaction {
+        if cursor.is_over(layout.bounds()) {
+            mouse::Interaction::Crosshair
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &mut self,
+        state: &mut Tree,
+        event: &iced_core::Event,
+        layout: iced_core::Layout<'_>,
+        cursor: mouse::Cursor,
+        _renderer: &cosmic::Renderer,
+        _clipboard: &mut dyn iced_core::Clipboard,
+        shell: &mut iced_core::Shell<'_, Msg>,
+        _viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+        let state = state.state.downcast_mut::<CanvasState>();
+
+        match event {
+            iced_core::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(point) = Self::point_at(cursor, bounds) {
+                    state.drag_start = Some(point);
+                    shell.publish((self.on_draft)(Some(AnnotationShape::new(
+                        self.tool, point, point,
+                    ))));
+                    shell.capture_event();
+                }
+            }
+            iced_core::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                let Some(start) = state.drag_start else {
+                    return;
+                };
+                let Some(end) = Self::point_at(cursor, bounds) else {
+                    return;
+                };
+
+                shell.publish((self.on_draft)(Some(AnnotationShape::new(
+                    self.tool, start, end,
+                ))));
+                shell.capture_event();
+            }
+            iced_core::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                let Some(start) = state.drag_start.take() else {
+                    return;
+                };
+                let Some(end) = Self::point_at(cursor, bounds) else {
+                    shell.publish((self.on_draft)(None));
+                    shell.capture_event();
+                    return;
+                };
+
+                shell.publish((self.on_draft)(None));
+                if start.distance(end) > 0.01 {
+                    shell.publish((self.on_commit)(AnnotationShape::new(
+                        self.tool, start, end,
+                    )));
+                }
+                shell.capture_event();
+            }
+            _ => {}
+        }
+    }
+
+    fn draw(
+        &self,
+        _tree: &Tree,
+        renderer: &mut cosmic::Renderer,
+        theme: &cosmic::Theme,
+        _style: &iced_core::renderer::Style,
+        layout: iced_core::Layout<'_>,
+        _cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+        let mut color = Color::from(theme.cosmic().accent_color());
+        color.a = 0.95;
+        let bounds = layout.bounds();
+
+        for shape in self.annotations.iter().chain(self.draft.iter()) {
+            draw_shape(renderer, *shape, bounds, color);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CanvasState {
+    drag_start: Option<AnnotationPoint>,
+}
+
+fn draw_shape(
+    renderer: &mut cosmic::Renderer,
+    shape: AnnotationShape,
+    bounds: Rectangle,
+    color: Color,
+) {
+    match shape {
+        AnnotationShape::Rectangle { start, end } => {
+            draw_rectangle(renderer, start, end, bounds, color)
+        }
+        AnnotationShape::Arrow { start, end } => draw_arrow(renderer, start, end, bounds, color),
+    }
+}
+
+fn draw_rectangle(
+    renderer: &mut cosmic::Renderer,
+    start: AnnotationPoint,
+    end: AnnotationPoint,
+    bounds: Rectangle,
+    color: Color,
+) {
+    let start = to_screen(start, bounds);
+    let end = to_screen(end, bounds);
+    let x = start.x.min(end.x);
+    let y = start.y.min(end.y);
+    let width = (start.x - end.x).abs();
+    let height = (start.y - end.y).abs();
+
+    renderer.fill_quad(
+        Quad {
+            bounds: Rectangle::new(Point::new(x, y), Size::new(width, height)),
+            border: Border {
+                radius: 0.0.into(),
+                width: 3.0,
+                color,
+            },
+            shadow: Shadow::default(),
+            snap: true,
+        },
+        Background::Color(Color::TRANSPARENT),
+    );
+}
+
+fn draw_arrow(
+    renderer: &mut cosmic::Renderer,
+    start: AnnotationPoint,
+    end: AnnotationPoint,
+    bounds: Rectangle,
+    color: Color,
+) {
+    let start = to_screen(start, bounds);
+    let end = to_screen(end, bounds);
+    draw_line(renderer, start, end, color);
+
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let angle = dy.atan2(dx);
+    let head_len = 22.0;
+    let spread = 0.55;
+
+    for head_angle in [
+        angle + std::f32::consts::PI - spread,
+        angle + std::f32::consts::PI + spread,
+    ] {
+        let head = Point::new(
+            end.x + head_len * head_angle.cos(),
+            end.y + head_len * head_angle.sin(),
+        );
+        draw_line(renderer, end, head, color);
+    }
+}
+
+fn draw_line(renderer: &mut cosmic::Renderer, start: Point, end: Point, color: Color) {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let steps = (dx.hypot(dy) / LINE_STEP).ceil().max(1.0) as u32;
+
+    for step in 0..=steps {
+        let t = step as f32 / steps as f32;
+        let point = Point::new(start.x + dx * t, start.y + dy * t);
+        renderer.fill_quad(
+            Quad {
+                bounds: Rectangle::new(
+                    Point::new(point.x - HANDLE_SIZE / 2.0, point.y - HANDLE_SIZE / 2.0),
+                    Size::new(HANDLE_SIZE, HANDLE_SIZE),
+                ),
+                border: Border {
+                    radius: (HANDLE_SIZE / 2.0).into(),
+                    ..Default::default()
+                },
+                shadow: Shadow::default(),
+                snap: true,
+            },
+            Background::Color(color),
+        );
+    }
+}
+
+fn to_screen(point: AnnotationPoint, bounds: Rectangle) -> Point {
+    Point::new(
+        bounds.x + point.x * bounds.width,
+        bounds.y + point.y * bounds.height,
+    )
+}
+
+impl<'a, Message> From<AnnotationCanvas<Message>> for cosmic::Element<'a, Message>
+where
+    Message: 'static + Clone,
+{
+    fn from(w: AnnotationCanvas<Message>) -> cosmic::Element<'a, Message> {
+        cosmic::Element::new(w)
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1,3 +1,4 @@
+pub mod annotation_canvas;
 pub mod keyboard_wrapper;
 pub mod output_selection;
 pub mod rectangle_selection;

--- a/src/widget/screenshot.rs
+++ b/src/widget/screenshot.rs
@@ -17,10 +17,11 @@ use wayland_client::protocol::wl_output::WlOutput;
 use crate::{
     app::OutputState,
     fl,
-    screenshot::{Choice, Rect, ScreenshotImage},
+    screenshot::{AnnotationShape, AnnotationState, AnnotationTool, Choice, Rect, ScreenshotImage},
 };
 
 use super::{
+    annotation_canvas::AnnotationCanvas,
     output_selection::OutputSelection,
     rectangle_selection::{DragState, RectangleSelection},
 };
@@ -60,6 +61,102 @@ impl<'a, Msg> ScreenshotSelection<'a, Msg>
 where
     Msg: 'static + Clone,
 {
+    pub fn new_annotation(
+        annotation: &AnnotationState,
+        on_capture: Msg,
+        on_cancel: Msg,
+        on_tool_change: impl Fn(AnnotationTool) -> Msg + 'static + Clone,
+        on_undo: Msg,
+        on_draft: impl Fn(Option<AnnotationShape>) -> Msg + 'static,
+        on_commit: impl Fn(AnnotationShape) -> Msg + 'static,
+        save_locations: &'a Vec<String>,
+        selected_save_location: usize,
+        dropdown_selected: impl Fn(usize) -> Msg + 'static + Clone,
+        spacing: Spacing,
+    ) -> Self {
+        let space_s = spacing.space_s;
+        let space_xs = spacing.space_xs;
+        let space_xxs = spacing.space_xxs;
+
+        let rectangle_button = button::custom(text(fl!("annotation-rectangle")))
+            .class(if annotation.tool == AnnotationTool::Rectangle {
+                cosmic::theme::Button::Suggested
+            } else {
+                cosmic::theme::Button::Standard
+            })
+            .on_press(on_tool_change(AnnotationTool::Rectangle));
+        let arrow_button = button::custom(text(fl!("annotation-arrow")))
+            .class(if annotation.tool == AnnotationTool::Arrow {
+                cosmic::theme::Button::Suggested
+            } else {
+                cosmic::theme::Button::Standard
+            })
+            .on_press(on_tool_change(AnnotationTool::Arrow));
+
+        Self {
+            id: cosmic::widget::Id::unique(),
+            choices: Vec::new(),
+            output_logical_geo: Vec::new(),
+            choice_labels: Vec::new(),
+            bg_element: image::Image::new(annotation.image.handle.clone())
+                .content_fit(ContentFit::Fill)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into(),
+            fg_element: AnnotationCanvas::new(
+                annotation.annotations.clone(),
+                annotation.draft,
+                annotation.tool,
+                on_draft,
+                on_commit,
+            )
+            .into(),
+            menu_element: cosmic::widget::container(
+                row![
+                    rectangle_button,
+                    arrow_button,
+                    button::custom(text(fl!("undo")))
+                        .on_press_maybe((!annotation.annotations.is_empty()).then_some(on_undo)),
+                    vertical::light().height(Length::Fixed(64.0)),
+                    button::custom(text(fl!("capture"))).on_press(on_capture),
+                    vertical::light().height(Length::Fixed(64.0)),
+                    Element::from(dropdown(
+                        save_locations.as_slice(),
+                        Some(selected_save_location),
+                        |i| i
+                    ))
+                    .map(dropdown_selected),
+                    vertical::light().height(Length::Fixed(64.0)),
+                    button::custom(
+                        icon::Icon::from(icon::from_name("window-close-symbolic").size(63))
+                            .width(Length::Fixed(40.0))
+                            .height(Length::Fixed(40.0))
+                    )
+                    .class(cosmic::theme::Button::Icon)
+                    .on_press(on_cancel),
+                ]
+                .align_y(cosmic::iced_core::Alignment::Center)
+                .spacing(space_s)
+                .padding([space_xxs, space_s, space_xxs, space_s]),
+            )
+            .class(cosmic::theme::Container::Custom(Box::new(|theme| {
+                let theme = theme.cosmic();
+                cosmic::iced::widget::container::Style {
+                    background: Some(Background::Color(theme.background.component.base.into())),
+                    text_color: Some(theme.background.component.on.into()),
+                    border: Border {
+                        radius: theme.corner_radii.radius_s.into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+            })))
+            .padding(space_xs)
+            .into(),
+            choice: Choice::Output(annotation.output_name.clone()),
+        }
+    }
+
     pub fn new(
         choice: Choice,
         image: &ScreenshotImage,


### PR DESCRIPTION
Adds an internal screenshot annotation mode that lets users mark up a captured screenshot before finalizing it.

This introduces rectangle and arrow annotation tools, undo support, keyboard shortcuts for capture/cancel/save/copy, and English/Turkish labels for the new controls.

Build-tested with cargo check. cargo build on my local machine is blocked by a missing system libgbm development library at link time. Manual runtime testing is pending.