### PR TITLE
feat: ColorPicker portal

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
-use crate::{access, config, file_chooser, screencast_dialog, screenshot, subscription};
+use crate::{
+    access, color_picker, config, file_chooser, screencast_dialog, screenshot, subscription,
+};
 use cosmic::Task;
 use cosmic::iced::{Length, Limits};
 use cosmic::iced_core::event::wayland::OutputEvent;
@@ -41,6 +43,7 @@ pub struct CosmicPortal {
     pub file_choosers: HashMap<window::Id, (file_chooser::Args, file_chooser::Dialog)>,
 
     pub screenshot_args: Option<screenshot::Args>,
+    pub color_picker_args: Option<color_picker::Args>,
     pub screencast_args: Option<screencast_dialog::Args>,
     pub screencast_tab_model:
         widget::segmented_button::Model<widget::segmented_button::SingleSelect>,
@@ -69,6 +72,7 @@ pub enum Msg {
     Access(access::Msg),
     FileChooser(window::Id, file_chooser::Msg),
     Screenshot(screenshot::Msg),
+    ColorPicker(color_picker::Msg),
     Screencast(screencast_dialog::Msg),
     Portal(subscription::Event),
     Output(OutputEvent, WlOutput),
@@ -118,6 +122,7 @@ impl cosmic::Application for CosmicPortal {
                 access_args: Default::default(),
                 file_choosers: Default::default(),
                 screenshot_args: Default::default(),
+                color_picker_args: Default::default(),
                 screencast_args: Default::default(),
                 screencast_tab_model: Default::default(),
                 location_options: Vec::new(),
@@ -154,7 +159,11 @@ impl cosmic::Application for CosmicPortal {
         } else if id == *screencast_dialog::SCREENCAST_ID {
             screencast_dialog::view(self).map(Msg::Screencast)
         } else if self.outputs.iter().any(|o| o.id == id) {
-            screenshot::view(self, id).map(Msg::Screenshot)
+            if self.color_picker_args.is_some() {
+                color_picker::view(self, id).map(Msg::ColorPicker)
+            } else {
+                screenshot::view(self, id).map(Msg::Screenshot)
+            }
         } else if self.dummy_id == id {
             widget::space::Space::new()
                 .width(Length::Fill)
@@ -180,6 +189,9 @@ impl cosmic::Application for CosmicPortal {
                 subscription::Event::Screenshot(args) => {
                     screenshot::update_args(self, args).map(cosmic::Action::App)
                 }
+                subscription::Event::ColorPicker(args) => {
+                    color_picker::update_args(self, args).map(cosmic::Action::App)
+                }
                 subscription::Event::Screencast(args) => {
                     screencast_dialog::update_args(self, args).map(cosmic::Action::App)
                 }
@@ -200,6 +212,7 @@ impl cosmic::Application for CosmicPortal {
                 }
             },
             Msg::Screenshot(m) => screenshot::update_msg(self, m).map(cosmic::Action::App),
+            Msg::ColorPicker(m) => color_picker::update_msg(self, m).map(cosmic::Action::App),
             Msg::Screencast(m) => screencast_dialog::update_msg(self, m).map(cosmic::Action::App),
             Msg::Output(o_event, wl_output) => {
                 match o_event {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
-use crate::{access, config, file_chooser, screencast_dialog, screenshot, subscription};
+use crate::{
+    access, color_picker, config, file_chooser, screencast_dialog, screenshot, subscription,
+};
 use cosmic::iced::core::event::wayland::OutputEvent;
 use cosmic::iced::platform_specific::shell::commands::layer_surface::get_layer_surface;
 use cosmic::iced::runtime::platform_specific::wayland::layer_surface::{
@@ -35,6 +37,7 @@ pub struct CosmicPortal {
     pub file_choosers: HashMap<window::Id, (file_chooser::Args, file_chooser::Dialog)>,
 
     pub screenshot_args: Option<screenshot::Args>,
+    pub color_picker_args: Option<color_picker::Args>,
     pub screencast_args: Option<screencast_dialog::Args>,
     pub screencast_tab_model:
         widget::segmented_button::Model<widget::segmented_button::SingleSelect>,
@@ -63,6 +66,7 @@ pub enum Msg {
     Access(access::Msg),
     FileChooser(window::Id, file_chooser::Msg),
     Screenshot(screenshot::Msg),
+    ColorPicker(color_picker::Msg),
     Screencast(screencast_dialog::Msg),
     Portal(subscription::Event),
     Output(OutputEvent, WlOutput),
@@ -112,6 +116,7 @@ impl cosmic::Application for CosmicPortal {
                 access_args: Default::default(),
                 file_choosers: Default::default(),
                 screenshot_args: Default::default(),
+                color_picker_args: Default::default(),
                 screencast_args: Default::default(),
                 screencast_tab_model: Default::default(),
                 location_options: Vec::new(),
@@ -148,7 +153,11 @@ impl cosmic::Application for CosmicPortal {
         } else if id == *screencast_dialog::SCREENCAST_ID {
             screencast_dialog::view(self).map(Msg::Screencast)
         } else if self.outputs.iter().any(|o| o.id == id) {
-            screenshot::view(self, id).map(Msg::Screenshot)
+            if self.color_picker_args.is_some() {
+                color_picker::view(self, id).map(Msg::ColorPicker)
+            } else {
+                screenshot::view(self, id).map(Msg::Screenshot)
+            }
         } else if self.dummy_id == id {
             widget::space::Space::new()
                 .width(Length::Fill)
@@ -174,6 +183,9 @@ impl cosmic::Application for CosmicPortal {
                 subscription::Event::Screenshot(args) => {
                     screenshot::update_args(self, args).map(cosmic::Action::App)
                 }
+                subscription::Event::ColorPicker(args) => {
+                    color_picker::update_args(self, args).map(cosmic::Action::App)
+                }
                 subscription::Event::Screencast(args) => {
                     screencast_dialog::update_args(self, args).map(cosmic::Action::App)
                 }
@@ -194,6 +206,7 @@ impl cosmic::Application for CosmicPortal {
                 }
             },
             Msg::Screenshot(m) => screenshot::update_msg(self, m).map(cosmic::Action::App),
+            Msg::ColorPicker(m) => color_picker::update_msg(self, m).map(cosmic::Action::App),
             Msg::Screencast(m) => screencast_dialog::update_msg(self, m).map(cosmic::Action::App),
             Msg::Output(o_event, wl_output) => {
                 match o_event {

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -1,0 +1,288 @@
+// Live PickColor portal implementation.
+//
+// Shows a transparent fullscreen layer surface over every output. As the user
+// moves the pointer, a small swatch next to the cursor is updated with the
+// color currently under the pointer (sampled via cosmic-comp's PickPixel D-Bus
+// method). A left-click returns the sampled color to the caller.
+//
+// Preview sampling is bounded: at most one pick is in flight at a time, and no
+// more than one pick per MIN_INTERVAL is dispatched. The most recent pointer
+// position seen during a request is captured in `pending` and dispatched as
+// soon as the previous pick completes.
+
+use std::time::{Duration, Instant};
+
+use cosmic::iced::{Limits, Point, window};
+use cosmic::iced_core::Length;
+use cosmic::iced_runtime::platform_specific::wayland::layer_surface::{
+    IcedOutput, SctkLayerSurfaceSettings,
+};
+use cosmic::iced_winit::commands::layer_surface::{destroy_layer_surface, get_layer_surface};
+use cosmic::widget::space;
+use cosmic_client_toolkit::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
+use tokio::sync::mpsc::Sender;
+use zbus::zvariant;
+
+use crate::PortalResponse;
+use crate::app::{CosmicPortal, OutputState};
+use crate::widget::color_picker::PickerArea;
+use crate::widget::keyboard_wrapper::KeyboardWrapper;
+
+/// Lower bound on the interval between PickPixel dispatches during preview.
+const MIN_INTERVAL: Duration = Duration::from_millis(16);
+
+#[zbus::proxy(
+    interface = "com.system76.CosmicComp.ColorPicker",
+    default_service = "com.system76.CosmicComp",
+    default_path = "/com/system76/CosmicComp/ColorPicker"
+)]
+trait CosmicCompColorPicker {
+    fn pick_pixel(&self, output: &str, x: i32, y: i32) -> zbus::Result<(f64, f64, f64)>;
+}
+
+#[derive(zvariant::SerializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct PickColorResult {
+    color: (f64, f64, f64),
+}
+
+#[derive(Clone, Debug)]
+pub struct Args {
+    pub handle: zvariant::ObjectPath<'static>,
+    pub app_id: String,
+    pub parent_window: String,
+    pub tx: Sender<PortalResponse<PickColorResult>>,
+    /// The portal's main session-bus connection, reused
+    /// so cosmic-comp's NameOwners check passes.
+    pub connection: zbus::Connection,
+    pub preview: Option<(f64, f64, f64)>,
+    pub pick_in_flight: bool,
+    pub last_dispatch: Option<Instant>,
+    pub pending: Option<(String, Point)>,
+    pub finalizing: bool,
+}
+
+impl Args {
+    pub fn new(
+        handle: zvariant::ObjectPath<'static>,
+        app_id: String,
+        parent_window: String,
+        tx: Sender<PortalResponse<PickColorResult>>,
+        connection: zbus::Connection,
+    ) -> Self {
+        Self {
+            handle,
+            app_id,
+            parent_window,
+            tx,
+            connection,
+            preview: None,
+            pick_in_flight: false,
+            last_dispatch: None,
+            pending: None,
+            finalizing: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Msg {
+    Motion {
+        output_name: String,
+        position: Point,
+    },
+    Clicked {
+        output_name: String,
+        position: Point,
+    },
+    Cancel,
+    Previewed(Result<(f64, f64, f64), String>),
+    Picked(Result<(f64, f64, f64), String>),
+}
+
+pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Task<crate::app::Msg> {
+    if portal.color_picker_args.replace(args).is_some() {
+        log::info!("Existing color picker args replaced");
+        return cosmic::Task::none();
+    }
+    let cmds: Vec<_> = portal
+        .outputs
+        .iter()
+        .map(|OutputState { output, id, .. }| {
+            get_layer_surface(SctkLayerSurfaceSettings {
+                id: *id,
+                layer: Layer::Overlay,
+                keyboard_interactivity: KeyboardInteractivity::Exclusive,
+                input_zone: None,
+                anchor: Anchor::all(),
+                output: IcedOutput::Output(output.clone()),
+                namespace: "color_picker".to_string(),
+                size: Some((None, None)),
+                exclusive_zone: -1,
+                size_limits: Limits::NONE.min_height(1.0).min_width(1.0),
+                ..Default::default()
+            })
+        })
+        .collect();
+    cosmic::Task::batch(cmds)
+}
+
+pub fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<'_, Msg> {
+    let Some(output) = portal.outputs.iter().find(|o| o.id == id) else {
+        return space::horizontal().width(Length::Fixed(1.0)).into();
+    };
+    let Some(args) = portal.color_picker_args.as_ref() else {
+        return space::horizontal().width(Length::Fixed(1.0)).into();
+    };
+    let output_name_motion = output.name.clone();
+    let output_name_click = output.name.clone();
+    let preview = args.preview;
+    KeyboardWrapper::new(
+        PickerArea::new(
+            move |pos| Msg::Motion {
+                output_name: output_name_motion.clone(),
+                position: pos,
+            },
+            move |pos| Msg::Clicked {
+                output_name: output_name_click.clone(),
+                position: pos,
+            },
+            preview,
+        ),
+        |key, _mods| match key {
+            cosmic::iced::keyboard::Key::Named(cosmic::iced::keyboard::key::Named::Escape) => {
+                Some(Msg::Cancel)
+            }
+            _ => None,
+        },
+    )
+    .into()
+}
+
+pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::app::Msg> {
+    match msg {
+        Msg::Motion {
+            output_name,
+            position,
+        } => {
+            let Some(args) = portal.color_picker_args.as_mut() else {
+                return cosmic::Task::none();
+            };
+            if args.finalizing {
+                return cosmic::Task::none();
+            }
+            args.pending = Some((output_name, position));
+            try_dispatch_preview(portal)
+        }
+        Msg::Previewed(res) => {
+            let Some(args) = portal.color_picker_args.as_mut() else {
+                return cosmic::Task::none();
+            };
+            args.pick_in_flight = false;
+            if let Ok(rgb) = res {
+                args.preview = Some(rgb);
+            }
+            try_dispatch_preview(portal)
+        }
+        Msg::Clicked {
+            output_name,
+            position,
+        } => {
+            let Some(args) = portal.color_picker_args.as_mut() else {
+                return cosmic::Task::none();
+            };
+            args.finalizing = true;
+            let conn = args.connection.clone();
+            let x = position.x.floor() as i32;
+            let y = position.y.floor() as i32;
+            let mut cmds: Vec<_> = portal
+                .outputs
+                .iter()
+                .map(|o| destroy_layer_surface(o.id))
+                .collect();
+            cmds.push(cosmic::Task::perform(
+                async move { pick_pixel_via_dbus(conn, output_name, x, y).await },
+                |res| crate::app::Msg::ColorPicker(Msg::Picked(res)),
+            ));
+            cosmic::Task::batch(cmds)
+        }
+        Msg::Picked(res) => {
+            let response = match res {
+                Ok(rgb) => PortalResponse::Success(PickColorResult { color: rgb }),
+                Err(e) => {
+                    log::error!("Color pick failed: {e}");
+                    PortalResponse::Other
+                }
+            };
+            finish(portal, response, /* destroy_surfaces */ false)
+        }
+        Msg::Cancel => finish(portal, PortalResponse::Cancelled, true),
+    }
+}
+
+fn try_dispatch_preview(portal: &mut CosmicPortal) -> cosmic::Task<crate::app::Msg> {
+    let args = match portal.color_picker_args.as_mut() {
+        Some(a) => a,
+        None => return cosmic::Task::none(),
+    };
+    if args.pick_in_flight || args.finalizing {
+        return cosmic::Task::none();
+    }
+    if let Some(last) = args.last_dispatch
+        && last.elapsed() < MIN_INTERVAL
+    {
+        return cosmic::Task::none();
+    }
+    let Some((output_name, position)) = args.pending.take() else {
+        return cosmic::Task::none();
+    };
+    args.pick_in_flight = true;
+    args.last_dispatch = Some(Instant::now());
+    let conn = args.connection.clone();
+    let x = position.x.floor() as i32;
+    let y = position.y.floor() as i32;
+    cosmic::Task::perform(
+        async move { pick_pixel_via_dbus(conn, output_name, x, y).await },
+        |res| crate::app::Msg::ColorPicker(Msg::Previewed(res)),
+    )
+}
+
+fn finish(
+    portal: &mut CosmicPortal,
+    response: PortalResponse<PickColorResult>,
+    destroy_surfaces: bool,
+) -> cosmic::Task<crate::app::Msg> {
+    let cmds: Vec<_> = if destroy_surfaces {
+        portal
+            .outputs
+            .iter()
+            .map(|o| destroy_layer_surface(o.id))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if let Some(args) = portal.color_picker_args.take() {
+        let tx = args.tx;
+        tokio::spawn(async move {
+            if let Err(err) = tx.send(response).await {
+                log::error!("Failed to send color picker response: {err}");
+            }
+        });
+    }
+    cosmic::Task::batch(cmds)
+}
+
+async fn pick_pixel_via_dbus(
+    conn: zbus::Connection,
+    output: String,
+    x: i32,
+    y: i32,
+) -> Result<(f64, f64, f64), String> {
+    let proxy = CosmicCompColorPickerProxy::new(&conn)
+        .await
+        .map_err(|e| format!("proxy: {e}"))?;
+    proxy
+        .pick_pixel(&output, x, y)
+        .await
+        .map_err(|e| format!("pick_pixel: {e}"))
+}

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -1,0 +1,265 @@
+// Live PickColor portal implementation.
+//
+// Shows a transparent fullscreen layer surface over every output. As the user
+// moves the pointer, a small swatch next to the cursor is updated with the
+// color currently under the pointer (sampled via cosmic-comp's
+// ColorUnderCursor D-Bus method, which resolves the pointer position
+// compositor-side so picking stays correct under screen magnification).
+// A left-click returns the sampled color to the caller.
+//
+// Preview sampling is bounded: at most one pick is in flight at a time, and no
+// more than one pick per MIN_INTERVAL is dispatched. A motion arriving while a
+// pick is in flight sets `pending`, which is dispatched as soon as the previous
+// pick completes.
+
+use std::time::{Duration, Instant};
+
+use cosmic::iced::core::Length;
+use cosmic::iced::platform_specific::shell::commands::layer_surface::{
+    destroy_layer_surface, get_layer_surface,
+};
+use cosmic::iced::runtime::platform_specific::wayland::layer_surface::{
+    IcedOutput, SctkLayerSurfaceSettings,
+};
+use cosmic::iced::{Limits, window};
+use cosmic::widget::space;
+use cosmic_client_toolkit::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
+use tokio::sync::mpsc::Sender;
+use zbus::zvariant;
+
+use crate::PortalResponse;
+use crate::app::{CosmicPortal, OutputState};
+use crate::widget::color_picker::PickerArea;
+use crate::widget::keyboard_wrapper::KeyboardWrapper;
+
+/// Lower bound on the interval between ColorUnderCursor dispatches during preview.
+const MIN_INTERVAL: Duration = Duration::from_millis(16);
+
+#[zbus::proxy(
+    interface = "com.system76.CosmicComp.ColorPicker",
+    default_service = "com.system76.CosmicComp",
+    default_path = "/com/system76/CosmicComp/ColorPicker"
+)]
+trait CosmicCompColorPicker {
+    /// Sample the colour under the compositor's current pointer. No coordinates
+    /// are sent: the compositor resolves the pointer position and any active
+    /// screen-magnifier transform itself, which keeps picking correct under
+    /// zoom and fractional scaling.
+    fn color_under_cursor(&self) -> zbus::Result<(f64, f64, f64)>;
+}
+
+#[derive(zvariant::SerializeDict, zvariant::Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct PickColorResult {
+    color: (f64, f64, f64),
+}
+
+#[derive(Clone, Debug)]
+pub struct Args {
+    pub handle: zvariant::ObjectPath<'static>,
+    pub app_id: String,
+    pub parent_window: String,
+    pub tx: Sender<PortalResponse<PickColorResult>>,
+    /// The portal's main session-bus connection, reused
+    /// so cosmic-comp's NameOwners check passes.
+    pub connection: zbus::Connection,
+    pub preview: Option<(f64, f64, f64)>,
+    pub pick_in_flight: bool,
+    pub last_dispatch: Option<Instant>,
+    /// A newer pointer motion arrived that still needs a preview sample.
+    pub pending: bool,
+    pub finalizing: bool,
+}
+
+impl Args {
+    pub fn new(
+        handle: zvariant::ObjectPath<'static>,
+        app_id: String,
+        parent_window: String,
+        tx: Sender<PortalResponse<PickColorResult>>,
+        connection: zbus::Connection,
+    ) -> Self {
+        Self {
+            handle,
+            app_id,
+            parent_window,
+            tx,
+            connection,
+            preview: None,
+            pick_in_flight: false,
+            last_dispatch: None,
+            pending: false,
+            finalizing: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Msg {
+    Motion,
+    Clicked,
+    Cancel,
+    Previewed(Result<(f64, f64, f64), String>),
+    Picked(Result<(f64, f64, f64), String>),
+}
+
+pub fn update_args(portal: &mut CosmicPortal, args: Args) -> cosmic::Task<crate::app::Msg> {
+    if portal.color_picker_args.replace(args).is_some() {
+        log::info!("Existing color picker args replaced");
+        return cosmic::Task::none();
+    }
+    let cmds: Vec<_> = portal
+        .outputs
+        .iter()
+        .map(|OutputState { output, id, .. }| {
+            get_layer_surface(SctkLayerSurfaceSettings {
+                id: *id,
+                layer: Layer::Overlay,
+                keyboard_interactivity: KeyboardInteractivity::Exclusive,
+                input_zone: None,
+                anchor: Anchor::all(),
+                output: IcedOutput::Output(output.clone()),
+                namespace: "color_picker".to_string(),
+                size: Some((None, None)),
+                exclusive_zone: -1,
+                size_limits: Limits::NONE.min_height(1.0).min_width(1.0),
+                ..Default::default()
+            })
+        })
+        .collect();
+    cosmic::Task::batch(cmds)
+}
+
+pub fn view(portal: &CosmicPortal, id: window::Id) -> cosmic::Element<'_, Msg> {
+    if !portal.outputs.iter().any(|o| o.id == id) {
+        return space::horizontal().width(Length::Fixed(1.0)).into();
+    }
+    let Some(args) = portal.color_picker_args.as_ref() else {
+        return space::horizontal().width(Length::Fixed(1.0)).into();
+    };
+    let preview = args.preview;
+    KeyboardWrapper::new(
+        PickerArea::new(move |_pos| Msg::Motion, move |_pos| Msg::Clicked, preview),
+        |key, _mods| match key {
+            cosmic::iced::keyboard::Key::Named(cosmic::iced::keyboard::key::Named::Escape) => {
+                Some(Msg::Cancel)
+            }
+            _ => None,
+        },
+    )
+    .into()
+}
+
+pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::app::Msg> {
+    match msg {
+        Msg::Motion => {
+            let Some(args) = portal.color_picker_args.as_mut() else {
+                return cosmic::Task::none();
+            };
+            if args.finalizing {
+                return cosmic::Task::none();
+            }
+            args.pending = true;
+            try_dispatch_preview(portal)
+        }
+        Msg::Previewed(res) => {
+            let Some(args) = portal.color_picker_args.as_mut() else {
+                return cosmic::Task::none();
+            };
+            args.pick_in_flight = false;
+            if let Ok(rgb) = res {
+                args.preview = Some(rgb);
+            }
+            try_dispatch_preview(portal)
+        }
+        Msg::Clicked => {
+            let Some(args) = portal.color_picker_args.as_mut() else {
+                return cosmic::Task::none();
+            };
+            args.finalizing = true;
+            let conn = args.connection.clone();
+            let mut cmds: Vec<_> = portal
+                .outputs
+                .iter()
+                .map(|o| destroy_layer_surface(o.id))
+                .collect();
+            cmds.push(cosmic::Task::perform(
+                async move { color_under_cursor_via_dbus(conn).await },
+                |res| crate::app::Msg::ColorPicker(Msg::Picked(res)),
+            ));
+            cosmic::Task::batch(cmds)
+        }
+        Msg::Picked(res) => {
+            let response = match res {
+                Ok(rgb) => PortalResponse::Success(PickColorResult { color: rgb }),
+                Err(e) => {
+                    log::error!("Color pick failed: {e}");
+                    PortalResponse::Other
+                }
+            };
+            finish(portal, response, /* destroy_surfaces */ false)
+        }
+        Msg::Cancel => finish(portal, PortalResponse::Cancelled, true),
+    }
+}
+
+fn try_dispatch_preview(portal: &mut CosmicPortal) -> cosmic::Task<crate::app::Msg> {
+    let args = match portal.color_picker_args.as_mut() {
+        Some(a) => a,
+        None => return cosmic::Task::none(),
+    };
+    if args.pick_in_flight || args.finalizing {
+        return cosmic::Task::none();
+    }
+    if let Some(last) = args.last_dispatch
+        && last.elapsed() < MIN_INTERVAL
+    {
+        return cosmic::Task::none();
+    }
+    if !args.pending {
+        return cosmic::Task::none();
+    }
+    args.pending = false;
+    args.pick_in_flight = true;
+    args.last_dispatch = Some(Instant::now());
+    let conn = args.connection.clone();
+    cosmic::Task::perform(
+        async move { color_under_cursor_via_dbus(conn).await },
+        |res| crate::app::Msg::ColorPicker(Msg::Previewed(res)),
+    )
+}
+
+fn finish(
+    portal: &mut CosmicPortal,
+    response: PortalResponse<PickColorResult>,
+    destroy_surfaces: bool,
+) -> cosmic::Task<crate::app::Msg> {
+    let cmds: Vec<_> = if destroy_surfaces {
+        portal
+            .outputs
+            .iter()
+            .map(|o| destroy_layer_surface(o.id))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if let Some(args) = portal.color_picker_args.take() {
+        let tx = args.tx;
+        tokio::spawn(async move {
+            if let Err(err) = tx.send(response).await {
+                log::error!("Failed to send color picker response: {err}");
+            }
+        });
+    }
+    cosmic::Task::batch(cmds)
+}
+
+async fn color_under_cursor_via_dbus(conn: zbus::Connection) -> Result<(f64, f64, f64), String> {
+    let proxy = CosmicCompColorPickerProxy::new(&conn)
+        .await
+        .map_err(|e| format!("proxy: {e}"))?;
+    proxy
+        .color_under_cursor()
+        .await
+        .map_err(|e| format!("color_under_cursor: {e}"))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ pub use cosmic_portal_config as config;
 mod access;
 mod app;
 mod buffer;
+mod color_picker;
 mod documents;
 mod file_chooser;
 mod localize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ pub use cosmic_portal_config as config;
 mod access;
 mod app;
 mod buffer;
+mod color_picker;
 mod documents;
 mod file_chooser;
 mod localize;

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -96,12 +96,6 @@ impl AsMimeTypes for ScreenshotBytes {
     }
 }
 
-#[derive(zvariant::SerializeDict, zvariant::Type)]
-#[zvariant(signature = "a{sv}")]
-struct PickColorResult {
-    color: (f64, f64, f64), // (ddd)
-}
-
 /// Logical Size and Position of a rectangle
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Rect {
@@ -567,14 +561,30 @@ impl Screenshot {
 
     async fn pick_color(
         &self,
+        #[zbus(connection)] connection: &zbus::Connection,
         handle: zvariant::ObjectPath<'_>,
         app_id: &str,
         parent_window: &str,
-        option: HashMap<String, zvariant::Value<'_>>,
-    ) -> PortalResponse<PickColorResult> {
-        // TODO create handle
-        // XXX implement
-        PortalResponse::Other
+        _option: HashMap<String, zvariant::Value<'_>>,
+    ) -> PortalResponse<crate::color_picker::PickColorResult> {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        if let Err(err) = self
+            .tx
+            .send(subscription::Event::ColorPicker(
+                crate::color_picker::Args::new(
+                    handle.to_owned(),
+                    app_id.to_string(),
+                    parent_window.to_string(),
+                    tx,
+                    connection.clone(),
+                ),
+            ))
+            .await
+        {
+            log::error!("Failed to send color picker event: {err}");
+            return PortalResponse::Other;
+        }
+        rx.recv().await.unwrap_or(PortalResponse::Cancelled)
     }
 
     #[zbus(property, name = "version")]

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -98,12 +98,6 @@ impl AsMimeTypes for ScreenshotBytes {
     }
 }
 
-#[derive(zvariant::SerializeDict, zvariant::Type)]
-#[zvariant(signature = "a{sv}")]
-struct PickColorResult {
-    color: (f64, f64, f64), // (ddd)
-}
-
 /// Logical Size and Position of a rectangle
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Rect {
@@ -569,14 +563,30 @@ impl Screenshot {
 
     async fn pick_color(
         &self,
+        #[zbus(connection)] connection: &zbus::Connection,
         handle: zvariant::ObjectPath<'_>,
         app_id: &str,
         parent_window: &str,
-        option: HashMap<String, zvariant::Value<'_>>,
-    ) -> PortalResponse<PickColorResult> {
-        // TODO create handle
-        // XXX implement
-        PortalResponse::Other
+        _option: HashMap<String, zvariant::Value<'_>>,
+    ) -> PortalResponse<crate::color_picker::PickColorResult> {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        if let Err(err) = self
+            .tx
+            .send(subscription::Event::ColorPicker(
+                crate::color_picker::Args::new(
+                    handle.to_owned(),
+                    app_id.to_string(),
+                    parent_window.to_string(),
+                    tx,
+                    connection.clone(),
+                ),
+            ))
+            .await
+        {
+            log::error!("Failed to send color picker event: {err}");
+            return PortalResponse::Other;
+        }
+        rx.recv().await.unwrap_or(PortalResponse::Cancelled)
     }
 
     #[zbus(property, name = "version")]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -9,8 +9,8 @@ use zbus::{Connection, fdo, zvariant};
 
 use crate::{
     ACCENT_COLOR_KEY, APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY, CONTRAST_KEY, ColorScheme, Contrast,
-    DBUS_NAME, DBUS_PATH, Settings, access::Access, config, file_chooser::FileChooser,
-    screencast::ScreenCast, screenshot::Screenshot, wayland,
+    DBUS_NAME, DBUS_PATH, Settings, access::Access, color_picker, config,
+    file_chooser::FileChooser, screencast::ScreenCast, screenshot::Screenshot, wayland,
 };
 
 #[derive(Clone, Debug)]
@@ -18,6 +18,7 @@ pub enum Event {
     Access(crate::access::AccessDialogArgs),
     FileChooser(crate::file_chooser::Args),
     Screenshot(crate::screenshot::Args),
+    ColorPicker(color_picker::Args),
     Screencast(crate::screencast_dialog::Args),
     CancelScreencast(zvariant::ObjectPath<'static>),
     Accent(Srgba),
@@ -125,6 +126,11 @@ pub(crate) async fn process_changes(
                     Event::Screenshot(args) => {
                         if let Err(err) = output.send(Event::Screenshot(args)).await {
                             log::error!("Error sending screenshot event: {:?}", err);
+                        };
+                    }
+                    Event::ColorPicker(args) => {
+                        if let Err(err) = output.send(Event::ColorPicker(args)).await {
+                            log::error!("Error sending color picker event: {:?}", err);
                         };
                     }
                     Event::Screencast(args) => {

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -15,7 +15,7 @@ use crate::screencast::ScreenCast;
 use crate::screenshot::Screenshot;
 use crate::{
     ACCENT_COLOR_KEY, APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY, CONTRAST_KEY, ColorScheme, Contrast,
-    DBUS_NAME, DBUS_PATH, Settings, config, wayland,
+    DBUS_NAME, DBUS_PATH, Settings, color_picker, config, wayland,
 };
 
 #[derive(Clone, Debug)]
@@ -23,6 +23,7 @@ pub enum Event {
     Access(crate::access::AccessDialogArgs),
     FileChooser(crate::file_chooser::Args),
     Screenshot(crate::screenshot::Args),
+    ColorPicker(color_picker::Args),
     Screencast(crate::screencast_dialog::Args),
     CancelScreencast(zvariant::ObjectPath<'static>),
     Accent(Srgba),
@@ -130,6 +131,11 @@ pub(crate) async fn process_changes(
                     Event::Screenshot(args) => {
                         if let Err(err) = output.send(Event::Screenshot(args)).await {
                             log::error!("Error sending screenshot event: {:?}", err);
+                        };
+                    }
+                    Event::ColorPicker(args) => {
+                        if let Err(err) = output.send(Event::ColorPicker(args)).await {
+                            log::error!("Error sending color picker event: {:?}", err);
                         };
                     }
                     Event::Screencast(args) => {

--- a/src/widget/color_picker.rs
+++ b/src/widget/color_picker.rs
@@ -1,0 +1,184 @@
+use cosmic::{
+    iced_core::{
+        Border, Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle, Renderer as _,
+        Shadow, Shell, Size, layout, mouse,
+        renderer::{self, Quad},
+        widget::Tree,
+    },
+    widget::Widget,
+};
+
+/// Fullscreen transparent overlay for the PickColor portal.
+pub struct PickerArea<Message> {
+    on_motion: Box<dyn Fn(Point) -> Message>,
+    on_click: Box<dyn Fn(Point) -> Message>,
+    preview: Option<(f64, f64, f64)>,
+}
+
+impl<Message> PickerArea<Message> {
+    pub fn new(
+        on_motion: impl Fn(Point) -> Message + 'static,
+        on_click: impl Fn(Point) -> Message + 'static,
+        preview: Option<(f64, f64, f64)>,
+    ) -> Self {
+        Self {
+            on_motion: Box::new(on_motion),
+            on_click: Box::new(on_click),
+            preview,
+        }
+    }
+}
+
+// Swatch sizing & offset relative to the cursor hotspot.
+const SWATCH_SIZE: f32 = 48.0;
+const SWATCH_OFFSET_X: f32 = 20.0;
+const SWATCH_OFFSET_Y: f32 = 20.0;
+const SWATCH_BORDER: f32 = 2.0;
+
+fn plain_quad(bounds: Rectangle, radius: f32) -> Quad {
+    Quad {
+        bounds,
+        border: Border {
+            radius: radius.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
+fn ring_quad(bounds: Rectangle, radius: f32, thickness: f32, color: Color) -> Quad {
+    Quad {
+        bounds,
+        border: Border {
+            radius: radius.into(),
+            width: thickness,
+            color,
+        },
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
+impl<Message> Widget<Message, cosmic::Theme, cosmic::Renderer> for PickerArea<Message>
+where
+    Message: Clone,
+{
+    fn size(&self) -> Size<Length> {
+        Size::new(Length::Fill, Length::Fill)
+    }
+
+    fn layout(
+        &mut self,
+        _tree: &mut Tree,
+        _renderer: &cosmic::Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        layout::Node::new(limits.max())
+    }
+
+    fn update(
+        &mut self,
+        _tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _renderer: &cosmic::Renderer,
+        _clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
+    ) {
+        match event {
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some(pos) = cursor.position_in(layout.bounds()) {
+                    shell.publish((self.on_motion)(pos));
+                }
+                shell.request_redraw();
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(pos) = cursor.position_in(layout.bounds()) {
+                    shell.publish((self.on_click)(pos));
+                    shell.capture_event();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &Tree,
+        _layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &cosmic::Renderer,
+    ) -> mouse::Interaction {
+        mouse::Interaction::Crosshair
+    }
+
+    fn draw(
+        &self,
+        _tree: &Tree,
+        renderer: &mut cosmic::Renderer,
+        _theme: &cosmic::Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+        let Some(cursor_pos) = cursor.position_in(bounds) else {
+            return;
+        };
+        let cx = bounds.x + cursor_pos.x;
+        let cy = bounds.y + cursor_pos.y;
+
+        // Position the swatch down-right of the cursor; flip to the opposite
+        // side when we'd otherwise run off-screen.
+        let flip_x = cx + SWATCH_OFFSET_X + SWATCH_SIZE > bounds.x + bounds.width;
+        let flip_y = cy + SWATCH_OFFSET_Y + SWATCH_SIZE > bounds.y + bounds.height;
+        let swatch_x = if flip_x {
+            cx - SWATCH_OFFSET_X - SWATCH_SIZE
+        } else {
+            cx + SWATCH_OFFSET_X
+        };
+        let swatch_y = if flip_y {
+            cy - SWATCH_OFFSET_Y - SWATCH_SIZE
+        } else {
+            cy + SWATCH_OFFSET_Y
+        };
+
+        let swatch_bounds = Rectangle::new(
+            Point::new(swatch_x, swatch_y),
+            Size::new(SWATCH_SIZE, SWATCH_SIZE),
+        );
+
+        let fill = match self.preview {
+            Some((r, g, b)) => Color::from_rgb(r as f32, g as f32, b as f32),
+            None => Color::from_rgba(0.5, 0.5, 0.5, 0.85),
+        };
+
+        let radius = 6.0;
+        renderer.fill_quad(plain_quad(swatch_bounds, radius), fill);
+        renderer.fill_quad(
+            ring_quad(
+                swatch_bounds,
+                radius,
+                SWATCH_BORDER,
+                Color::from_rgba(0.0, 0.0, 0.0, 0.85),
+            ),
+            Color::TRANSPARENT,
+        );
+    }
+}
+
+impl<'a, Message> From<PickerArea<Message>>
+    for Element<'a, Message, cosmic::Theme, cosmic::Renderer>
+where
+    Message: 'a + Clone,
+{
+    fn from(area: PickerArea<Message>) -> Self {
+        Element::new(area)
+    }
+}

--- a/src/widget/color_picker.rs
+++ b/src/widget/color_picker.rs
@@ -1,0 +1,192 @@
+use cosmic::iced::core::renderer::{self, Quad};
+use cosmic::iced::core::widget::Tree;
+use cosmic::iced::core::{
+    Border, Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle, Renderer as _,
+    Shadow, Shell, Size, layout, mouse,
+};
+use cosmic::widget::Widget;
+
+/// Fullscreen transparent overlay for the PickColor portal.
+pub struct PickerArea<Message> {
+    on_motion: Box<dyn Fn(Point) -> Message>,
+    on_click: Box<dyn Fn(Point) -> Message>,
+    preview: Option<(f64, f64, f64)>,
+}
+
+impl<Message> PickerArea<Message> {
+    pub fn new(
+        on_motion: impl Fn(Point) -> Message + 'static,
+        on_click: impl Fn(Point) -> Message + 'static,
+        preview: Option<(f64, f64, f64)>,
+    ) -> Self {
+        Self {
+            on_motion: Box::new(on_motion),
+            on_click: Box::new(on_click),
+            preview,
+        }
+    }
+}
+
+// Swatch sizing & offset relative to the cursor hotspot.
+const SWATCH_SIZE: f32 = 48.0;
+const SWATCH_OFFSET_X: f32 = 20.0;
+const SWATCH_OFFSET_Y: f32 = 20.0;
+const SWATCH_BORDER: f32 = 2.0;
+
+fn plain_quad(bounds: Rectangle, radius: f32) -> Quad {
+    Quad {
+        bounds,
+        border: Border {
+            radius: radius.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
+fn ring_quad(bounds: Rectangle, radius: f32, thickness: f32, color: Color) -> Quad {
+    Quad {
+        bounds,
+        border: Border {
+            radius: radius.into(),
+            width: thickness,
+            color,
+        },
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
+impl<Message> Widget<Message, cosmic::Theme, cosmic::Renderer> for PickerArea<Message>
+where
+    Message: Clone,
+{
+    fn size(&self) -> Size<Length> {
+        Size::new(Length::Fill, Length::Fill)
+    }
+
+    fn layout(
+        &mut self,
+        _tree: &mut Tree,
+        _renderer: &cosmic::Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        layout::Node::new(limits.max())
+    }
+
+    fn update(
+        &mut self,
+        _tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _renderer: &cosmic::Renderer,
+        _clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
+    ) {
+        match event {
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some(pos) = cursor.position_in(layout.bounds()) {
+                    shell.publish((self.on_motion)(pos));
+                }
+                shell.request_redraw();
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(pos) = cursor.position_in(layout.bounds()) {
+                    shell.publish((self.on_click)(pos));
+                    shell.capture_event();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &cosmic::Renderer,
+    ) -> mouse::Interaction {
+        // Only report Crosshair while the pointer is actually over the surface.
+        // libcosmic's wayland backend applies the cursor only when the
+        // interaction *changes*; reporting Crosshair unconditionally latches it
+        // before the pointer enters (a no-op), so it would never re-apply and
+        // the default cursor would persist. Gating on `is_over` makes the
+        // interaction transition None -> Crosshair after the pointer is focused.
+        if cursor.is_over(layout.bounds()) {
+            mouse::Interaction::Crosshair
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn draw(
+        &self,
+        _tree: &Tree,
+        renderer: &mut cosmic::Renderer,
+        _theme: &cosmic::Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+        let Some(cursor_pos) = cursor.position_in(bounds) else {
+            return;
+        };
+        let cx = bounds.x + cursor_pos.x;
+        let cy = bounds.y + cursor_pos.y;
+
+        // Position the swatch down-right of the cursor; flip to the opposite
+        // side when we'd otherwise run off-screen.
+        let flip_x = cx + SWATCH_OFFSET_X + SWATCH_SIZE > bounds.x + bounds.width;
+        let flip_y = cy + SWATCH_OFFSET_Y + SWATCH_SIZE > bounds.y + bounds.height;
+        let swatch_x = if flip_x {
+            cx - SWATCH_OFFSET_X - SWATCH_SIZE
+        } else {
+            cx + SWATCH_OFFSET_X
+        };
+        let swatch_y = if flip_y {
+            cy - SWATCH_OFFSET_Y - SWATCH_SIZE
+        } else {
+            cy + SWATCH_OFFSET_Y
+        };
+
+        let swatch_bounds = Rectangle::new(
+            Point::new(swatch_x, swatch_y),
+            Size::new(SWATCH_SIZE, SWATCH_SIZE),
+        );
+
+        let fill = match self.preview {
+            Some((r, g, b)) => Color::from_rgb(r as f32, g as f32, b as f32),
+            None => Color::from_rgba(0.5, 0.5, 0.5, 0.85),
+        };
+
+        let radius = 6.0;
+        renderer.fill_quad(plain_quad(swatch_bounds, radius), fill);
+        renderer.fill_quad(
+            ring_quad(
+                swatch_bounds,
+                radius,
+                SWATCH_BORDER,
+                Color::from_rgba(0.0, 0.0, 0.0, 0.85),
+            ),
+            Color::TRANSPARENT,
+        );
+    }
+}
+
+impl<'a, Message> From<PickerArea<Message>>
+    for Element<'a, Message, cosmic::Theme, cosmic::Renderer>
+where
+    Message: 'a + Clone,
+{
+    fn from(area: PickerArea<Message>) -> Self {
+        Element::new(area)
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1,3 +1,4 @@
+pub mod color_picker;
 pub mod keyboard_wrapper;
 pub mod output_selection;
 pub mod rectangle_selection;


### PR DESCRIPTION
This implements ColorPicker portal.

There are 4 ways to implement it:
- Take a screen shot and let the user choose a pixel on that frozen frame (live update, frozen frame, cheap)
- Lay a transparent surface over the desktop, as soon as the user clicks, take a screenshot and sample (no live update, no frozen frame, cheap) 
- Keep copying the current output and sampling where the cursor (live update, no frozen frame, expensive)
- Ask cosmic-comp! (live update, no frozen frame, cheap)

I've chosen the last method. Since freezing frame is bad UX and nobody does it, and live update is important.

Now, we can create a wayland protocol to talk to cosmic-comp, or just a dbus interface. I've chosen to go with the dbus interface. That's what gnome does too.
- [ ] Depends on https://github.com/pop-os/cosmic-comp/pull/2319

The UI can be improved in the future, when we have designs for it.

https://github.com/user-attachments/assets/2294234e-7c27-41ea-b5b2-fc99008fec09



___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

