### PR TITLE
Fix : Replace wgpu mesh overlay with portable fill_quad approach for dark background overlay around selection

### DIFF
--- a/src/widget/rectangle_selection.rs
+++ b/src/widget/rectangle_selection.rs
@@ -492,60 +492,6 @@ impl<Msg: 'static + Clone> Widget<Msg, cosmic::Theme, cosmic::Renderer>
         let Some(clipped_inner_rect) = inner_rect.intersection(&outer_rect) else {
             return;
         };
-        #[cfg(feature = "wgpu")]
-        {
-            use cosmic::iced_widget::graphics::{
-                Mesh,
-                color::{Packed, pack},
-                mesh::{Indexed, SolidVertex2D},
-            };
-            let mut overlay = Color::BLACK;
-            overlay.a = 0.3;
-
-            let outer_bottom_right = (outer_size.width, outer_size.height);
-            let inner_top_left = (inner_rect.x, inner_rect.y);
-            let outer_top_left = (outer_rect.x, outer_rect.y);
-            let inner_bottom_right = (
-                inner_rect.x + inner_rect.width,
-                inner_rect.y + inner_rect.height,
-            );
-            let vertices = vec![
-                outer_top_left,
-                (outer_bottom_right.0, outer_top_left.1),
-                outer_bottom_right,
-                (outer_top_left.0, outer_bottom_right.1),
-                inner_top_left,
-                (inner_bottom_right.0, inner_top_left.1),
-                inner_bottom_right,
-                (inner_top_left.0, inner_bottom_right.1),
-            ];
-            // build 8 triangles around the selected region
-            #[rustfmt::skip]
-            let indices = vec![
-                5, 2, 1,
-                5, 6, 2,
-                6, 4, 2,
-                6, 8, 4,
-                8, 3, 4,
-                8, 7, 3,
-                7, 1, 3,
-                7, 5, 1,
-            ];
-
-            renderer.draw_mesh(Mesh::Solid {
-                buffers: Indexed {
-                    vertices: vertices
-                        .into_iter()
-                        .map(|v| SolidVertex2D {
-                            position: [v.0, v.1],
-                            color: pack(overlay),
-                        })
-                        .collect(),
-                    indices,
-                },
-                size: outer_size,
-            })
-        }
 
         let translated_clipped_inner_rect = Rectangle::new(
             Point::new(
@@ -554,6 +500,62 @@ impl<Msg: 'static + Clone> Widget<Msg, cosmic::Theme, cosmic::Renderer>
             ),
             clipped_inner_rect.size(),
         );
+        let selection_right = translated_clipped_inner_rect.x + translated_clipped_inner_rect.width;
+        let selection_bottom =
+            translated_clipped_inner_rect.y + translated_clipped_inner_rect.height;
+
+        let overlay = Color {
+            a: 0.45,
+            ..Color::BLACK
+        };
+
+        let overlay_rects = [
+            // top
+            Rectangle::new(
+                Point::new(0.0, 0.0),
+                Size::new(outer_size.width, translated_clipped_inner_rect.y.max(0.0)),
+            ),
+            // bottom
+            Rectangle::new(
+                Point::new(0.0, selection_bottom),
+                Size::new(
+                    outer_size.width,
+                    (outer_size.height - selection_bottom).max(0.0),
+                ),
+            ),
+            // left
+            Rectangle::new(
+                Point::new(0.0, translated_clipped_inner_rect.y),
+                Size::new(
+                    translated_clipped_inner_rect.x.max(0.0),
+                    translated_clipped_inner_rect.height,
+                ),
+            ),
+            // right
+            Rectangle::new(
+                Point::new(selection_right, translated_clipped_inner_rect.y),
+                Size::new(
+                    (outer_size.width - selection_right).max(0.0),
+                    translated_clipped_inner_rect.height,
+                ),
+            ),
+        ];
+        for bounds in overlay_rects {
+            if bounds.width > 0.0 && bounds.height > 0.0 {
+                let quad = Quad {
+                    bounds,
+                    border: Border {
+                        radius: 0.0.into(),
+                        width: 0.0,
+                        color: Color::TRANSPARENT,
+                    },
+                    shadow: Shadow::default(),
+                    snap: true,
+                };
+                renderer.fill_quad(quad, overlay);
+            }
+        }
+
         let quad = Quad {
             bounds: translated_clipped_inner_rect,
             border: Border {


### PR DESCRIPTION
This PR replaces the mesh-based approach with four `fill_quad` calls (top, bottom, left, right), which work across all backends.

- The overlay now renders correctly regardless of the backend in use
- No functional difference is expected for wgpu users

### Notes
- Overlay opacity changed slightly from 0.3 to 0.45 for better visual contrast
- The `#[cfg(feature = "wgpu")]` block is removed entirely; if there is a reason to keep a wgpu-specific fast path, that can be revisited

AI assistance: parts of this code were refined with Claude (calculation of the overlay rectangles around selection).

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

