### PR TITLE
feat: add option to toggle cursor visibility in screencast prompt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -11,5 +11,6 @@ This document provides a regression testing checklist for the COSMIC XDG desktop
     - [ ] Latest screenshot's copied to clipboard
 - [ ] PipeWire screen capture from OBS with the portal prompt works
 - [ ] Webcam and screen sharing prompted through Firefox works
+    - [ ] The screen share prompt can toggle cursor visibility
 - [ ] The file chooser works from Firefox
 - [ ] The file chooser, webcam, and screen share work from the Slack flatpak

--- a/i18n/en/xdg_desktop_portal_cosmic.ftl
+++ b/i18n/en/xdg_desktop_portal_cosmic.ftl
@@ -13,3 +13,4 @@ share-screen = Share your screen
 unknown-application = Unknown Application
 output = Output
 window = Window
+show-cursor = Show cursor

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -246,7 +246,7 @@ impl ScreenCast {
                 return PortalResponse::Other;
             };
 
-            let (cursor_mode, multiple, source_types, persisted_capture_sources) = {
+            let (requested_cursor_mode, multiple, source_types, persisted_capture_sources) = {
                 let session_data = interface.get_mut().await;
                 let cursor_mode = session_data.cursor_mode.unwrap_or(CURSOR_MODE_HIDDEN);
                 let multiple = session_data.multiple;
@@ -270,7 +270,7 @@ impl ScreenCast {
             let capture_sources = if let Some(capture_sources) =
                 persisted_capture_sources.and_then(|x| x.to_capture_sources(&self.wayland_helper))
             {
-                capture_sources
+                (capture_sources, requested_cursor_mode)
             } else {
                 // Show dialog to prompt for what to capture
                 let resp = screencast_dialog::show_screencast_prompt(
@@ -279,15 +279,22 @@ impl ScreenCast {
                     app_id,
                     multiple,
                     source_types,
+                    requested_cursor_mode == CURSOR_MODE_EMBEDDED,
                     &self.wayland_helper,
                 )
                 .await;
-                let Some(capture_sources) = resp else {
+                let Some(selection) = resp else {
                     return PortalResponse::Cancelled;
                 };
-                capture_sources
+                let cursor_mode = if selection.show_cursor {
+                    CURSOR_MODE_EMBEDDED
+                } else {
+                    CURSOR_MODE_HIDDEN
+                };
+                (selection.capture_sources, cursor_mode)
             };
 
+            let (capture_sources, cursor_mode) = capture_sources;
             let overlay_cursor = cursor_mode == CURSOR_MODE_EMBEDDED;
             // Use `FuturesOrdered` so streams are in consistent order
             let mut res_futures = FuturesOrdered::new();

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -50,8 +50,9 @@ pub async fn show_screencast_prompt(
     app_id: String,
     multiple: bool,
     source_types: BitFlags<SourceType>,
+    show_cursor: bool,
     wayland_helper: &WaylandHelper,
-) -> Option<CaptureSources> {
+) -> Option<Selection> {
     let locales = get_languages_from_env();
     let desktop_entries = load_desktop_entries(&locales).await;
 
@@ -91,6 +92,7 @@ pub async fn show_screencast_prompt(
         toplevels,
         multiple,
         source_types,
+        show_cursor,
         app_name,
         tx,
         capture_sources: Default::default(),
@@ -140,16 +142,17 @@ pub struct Args {
     session_handle: zvariant::ObjectPath<'static>,
     multiple: bool,
     source_types: BitFlags<SourceType>,
+    show_cursor: bool,
     outputs: Vec<(WlOutput, OutputInfo, Option<widget::image::Handle>)>,
     toplevels: Vec<(ToplevelInfo, Option<String>)>,
     app_name: Option<String>,
     // Should be oneshot, but need `Clone` bound
-    tx: mpsc::Sender<Option<CaptureSources>>,
+    tx: mpsc::Sender<Option<Selection>>,
     capture_sources: CaptureSources,
 }
 
 impl Args {
-    fn send_response(self, response: Option<CaptureSources>) {
+    fn send_response(self, response: Option<Selection>) {
         tokio::spawn(async move {
             if let Err(err) = self.tx.send(response).await {
                 log::error!("Failed to send screencast event: {}", err);
@@ -177,10 +180,17 @@ impl CaptureSources {
 }
 
 #[derive(Clone, Debug)]
+pub struct Selection {
+    pub capture_sources: CaptureSources,
+    pub show_cursor: bool,
+}
+
+#[derive(Clone, Debug)]
 pub enum Msg {
     ActivateTab(widget::segmented_button::Entity),
     SelectOutput(WlOutput),
     SelectToplevel(ExtForeignToplevelHandleV1),
+    ShowCursor(bool),
     Share,
     Cancel,
 }
@@ -228,9 +238,15 @@ pub fn update_msg(portal: &mut CosmicPortal, msg: Msg) -> cosmic::Task<crate::ap
                 args.capture_sources.toplevels.push(toplevel);
             }
         }
+        Msg::ShowCursor(show_cursor) => {
+            args.show_cursor = show_cursor;
+        }
         Msg::Share => {
             if let Some(mut args) = portal.screencast_args.take() {
-                let response = mem::take(&mut args.capture_sources);
+                let response = Selection {
+                    capture_sources: mem::take(&mut args.capture_sources),
+                    show_cursor: args.show_cursor,
+                };
                 args.send_response(Some(response));
                 return destroy_layer_surface(*SCREENCAST_ID);
             }
@@ -447,7 +463,10 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
     let unknown = fl!("unknown-application");
     let app_name = args.app_name.as_deref().unwrap_or(&unknown);
 
-    let control = widget::column::with_children(vec![tabs.into(), list]).spacing(8);
+    let show_cursor = widget::settings::item::builder(fl!("show-cursor"))
+        .toggler(args.show_cursor, Msg::ShowCursor);
+    let control =
+        widget::column::with_children(vec![tabs.into(), list, show_cursor.into()]).spacing(8);
     autosize::autosize(
         KeyboardWrapper::new(
             widget::dialog()


### PR DESCRIPTION
I've build a toggle for the cursor visibility with copilot GPT-5.4. I do not understand rust that well.

It is an alternative and references this PR: https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/99

Here is a screenshot: 
<img width="1048" height="870" alt="image" src="https://github.com/user-attachments/assets/d6aa34ca-c0af-4c52-b627-38234efa4e05" />
