### PR TITLE
data: Use oo7-portal as secret portal

### DIFF
--- a/data/cosmic-portals.conf
+++ b/data/cosmic-portals.conf
@@ -1,3 +1,3 @@
 [preferred]
 default=cosmic;gtk;
-org.freedesktop.impl.portal.Secret=gnome-keyring;
+org.freedesktop.impl.portal.Secret=oo7-portal;gnome-keyring;


### PR DESCRIPTION
GNOME & KDE are moving away from gnome-keyring/kwallet to oo7, a new DE-agnostic secrets storage implementation in Rust.

Ref: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/work_items/1253
Ref: https://invent.kde.org/kde-linux/kde-linux/-/work_items/566

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

