### PR TITLE
fix: Wayland dispatch termination handling

### DIFF
--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -269,7 +269,13 @@ impl WaylandHelper {
 
         thread::spawn(move || {
             loop {
-                event_queue.blocking_dispatch(&mut data).unwrap();
+                match event_queue.blocking_dispatch(&mut data) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        log::debug!("Wayland dispatch: {error}");
+                        break;
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
Closes #282 

`main` - panics on exit:

```
$ journalctl
<snip>
May 13 05:11:49 karl-mba xdg-desktop-portal-cosmic[3125]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
May 13 05:11:49 karl-mba xdg-desktop-portal-cosmic[3125]: called `Result::unwrap()` on an `Err` value: Backend(Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }))
May 13 05:11:49 karl-mba xdg-desktop-portal-cosmic[3125]: thread '<unnamed>' (3188) panicked at src/wayland/mod.rs:284:58:
May 13 05:11:49 karl-mba xdg-desktop-portal-cosmic[3125]: Io error: Broken pipe (os error 32)
```

Without panicing in `new()`, shutdown loops:

```
$ journalctl
<snip>

May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: [2026-05-16T07:35:18Z ERROR iced_winit::platform_specific::wayland::event_loop] SCTK failed to send Control::AboutToWait. TrySendError { >
May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: [2026-05-16T07:35:18Z ERROR iced_winit::platform_specific::wayland::event_loop] SCTK dispatch error: underlying IO error: Broken pipe (os>
May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: Error: EventLoop(ExitFailure(1))

<BELOW LOOPS MANY TIMES>
May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: Error trying to flush the wayland display: Broken pipe (os error 32)
May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: [2026-05-16T07:35:18Z ERROR iced_winit::platform_specific::wayland::event_loop] SCTK dispatch error: underlying IO error: Broken pipe (os>
May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: Error trying to flush the wayland display: Broken pipe (os error 32)
May 16 17:35:18 karl-mba xdg-desktop-portal-cosmic[3138]: [2026-05-16T07:35:18Z ERROR iced_winit::platform_specific::wayland::event_loop] SCTK dispatch error: underlying IO error: Broken pipe (os>
```

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

