### PR TITLE
Restart portal after subscription failures

### DIFF
--- a/data/org.freedesktop.impl.portal.desktop.cosmic.service.in
+++ b/data/org.freedesktop.impl.portal.desktop.cosmic.service.in
@@ -5,3 +5,5 @@ Description=Portal service (COSMIC implementation)
 Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.cosmic
 ExecStart=@libexecdir@/xdg-desktop-portal-cosmic
+Restart=on-failure
+RestartSec=1s

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,10 @@ use cosmic::iced::{Event, Length, Limits, Subscription, event, window};
 use cosmic::{Task, app, cosmic_config, widget};
 use cosmic_client_toolkit::sctk::shell::wlr_layer;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use wayland_client::protocol::wl_output::WlOutput;
+
+static SUBSCRIPTION_FAILED: AtomicBool = AtomicBool::new(false);
 
 pub(crate) fn run() -> cosmic::iced::Result {
     let settings = cosmic::app::Settings::default()
@@ -20,6 +23,10 @@ pub(crate) fn run() -> cosmic::iced::Result {
         config_handler,
     };
     cosmic::app::run::<CosmicPortal>(settings, flags)
+}
+
+pub(crate) fn subscription_failed() -> bool {
+    SUBSCRIPTION_FAILED.load(Ordering::Relaxed)
 }
 
 // run iced app with no main surface
@@ -190,6 +197,11 @@ impl cosmic::Application for CosmicPortal {
                 }
                 subscription::Event::NameLost => {
                     log::warn!("'{}' name on bus lost. Exiting.", crate::DBUS_NAME);
+                    cosmic::iced::exit()
+                }
+                subscription::Event::SubscriptionFailed(err) => {
+                    log::error!("Portal subscription failed: {err}. Exiting.");
+                    SUBSCRIPTION_FAILED.store(true, Ordering::Relaxed);
                     cosmic::iced::exit()
                 }
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,5 +330,11 @@ impl Settings {
 fn main() -> cosmic::iced::Result {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
     localize::localize();
-    app::run()
+    let result = app::run();
+    if result.is_ok() && app::subscription_failed() {
+        return Err(cosmic::iced::Error::EventLoop(Box::new(
+            std::io::Error::new(std::io::ErrorKind::Other, "portal subscription failed"),
+        )));
+    }
+    result
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 use cosmic::cosmic_theme::palette::Srgba;
 use cosmic::iced::Subscription;
-use futures::{SinkExt, StreamExt, future};
+use futures::{SinkExt, StreamExt};
 use tokio::sync::mpsc::Receiver;
 use zbus::{Connection, fdo, zvariant};
 
@@ -31,6 +31,7 @@ pub enum Event {
     Config(config::Config),
     Init(tokio::sync::mpsc::Sender<Event>),
     NameLost,
+    SubscriptionFailed(String),
 }
 
 pub enum State {
@@ -57,8 +58,10 @@ pub(crate) fn portal_subscription(
                 let mut state = State::Init;
                 loop {
                     if let Err(err) = process_changes(&mut state, &mut output, &helper).await {
-                        log::debug!("Portal Subscription Error: {:?}", err);
-                        future::pending::<()>().await;
+                        let _ = output
+                            .send(Event::SubscriptionFailed(format!("{err:?}")))
+                            .await;
+                        break;
                     }
                 }
             })
@@ -204,6 +207,7 @@ pub(crate) async fn process_changes(
                     }
                     Event::Init(_) => {}
                     Event::NameLost => {}
+                    Event::SubscriptionFailed(_) => {}
                 }
             }
         }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary
- Route portal subscription failures back through the application update loop instead of parking the subscription forever.
- Shut down with `iced::exit()` so the runtime can cancel in-flight work and clean up resources.
- Return an error from `main` after the runtime unwinds, allowing systemd to recover the D-Bus service via `Restart=on-failure`.

## Findings
On a live COSMIC session, screenshot capture and clipboard paste stopped working after idle time while `xdg-desktop-portal-cosmic` remained active. Restarting only the COSMIC portal backend restored screenshot and image clipboard functionality.

The subscription error path currently logs at debug level and awaits pending forever. That can leave the service active from systemd and D-Bus perspectives, but unable to recover from the failed subscription path.

## Testing
- `cargo fmt --check`
- `CARGO_HOME=/tmp/cosmic-cargo-home CARGO_TARGET_DIR=/tmp/cosmic-xdp-target cargo check --locked`
- Local smoke: restarted patched user service and captured a screenshot with `cosmic-screenshot --interactive=false --notify=false --save-dir /tmp`
