### PR TITLE
Better output arrangement in screencast dialog

### DIFF
--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -313,35 +313,29 @@ fn output_button_appearance(
     appearance
 }
 
-fn output_button<'a>(
-    label: &'a str,
+fn output_thumb_button<'a>(
     is_selected: bool,
     image_handle: Option<&'a widget::image::Handle>,
+    width: f32,
+    height: f32,
     msg: Msg,
 ) -> cosmic::Element<'a, Msg> {
-    let text = widget::text(label).class(theme::style::Text::Custom(|theme| {
-        let container = theme.current_container();
-        iced::core::widget::text::Style {
-            color: Some(container.on.into()),
-            ..Default::default()
-        }
-    }));
-    let mut row_children = vec![text.into()];
-    if is_selected {
-        row_children.push(widget::text("✓").into());
-    }
-    let row = widget::row::with_children(row_children).spacing(12);
+    let content: cosmic::Element<'a, Msg> = match image_handle {
+        Some(image_handle) => widget::image::Image::new(image_handle.clone())
+            .width(iced::Length::Fill)
+            .height(iced::Length::Fill)
+            .content_fit(iced::ContentFit::Fill)
+            .into(),
+        None => widget::container(widget::text(""))
+            .width(iced::Length::Fill)
+            .height(iced::Length::Fill)
+            .into(),
+    };
 
-    let mut children = Vec::new();
-    if let Some(image_handle) = image_handle {
-        children.push(widget::image::Image::new(image_handle.clone()).into());
-    }
-    children.push(row.into());
-    let column = widget::column::with_children(children).spacing(12);
-
-    widget::button::custom(column)
-        .width(iced::Length::Fill)
-        .padding(8)
+    widget::button::custom(content)
+        .width(iced::Length::Fixed(width))
+        .height(iced::Length::Fixed(height))
+        .padding(0)
         .selected(is_selected)
         .class(cosmic::theme::Button::Custom {
             active: Box::new(move |_focused, theme| {
@@ -408,18 +402,63 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
 
     let list: cosmic::Element<_> = match active_tab(portal) {
         Tab::Outputs => {
+            // Position each output to match the display arrangement (as in the
+            // cosmic-settings display page), scaled to fit the dialog.
+            let geometry = |info: &OutputInfo| {
+                let (x, y) = info.logical_position.unwrap_or((0, 0));
+                let (w, h) = info.logical_size.unwrap_or((1920, 1080));
+                (x, y, w.max(1), h.max(1))
+            };
+
+            let (mut min_x, mut min_y) = (i32::MAX, i32::MAX);
+            let (mut max_x, mut max_y) = (i32::MIN, i32::MIN);
+            for (_, info, _) in &args.outputs {
+                let (x, y, w, h) = geometry(info);
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x + w);
+                max_y = max_y.max(y + h);
+            }
+            let bbox_w = (max_x - min_x).max(1) as f32;
+            let bbox_h = (max_y - min_y).max(1) as f32;
+
+            // Scale the arrangement to fit a target area, and inset each region so
+            // adjacent screens have a gap.
+            const TARGET_W: f32 = 520.0;
+            const TARGET_H: f32 = 320.0;
+            const GAP: f32 = 6.0;
+            let scale = (TARGET_W / bbox_w).min(TARGET_H / bbox_h);
+
             let mut children = Vec::new();
-            for (output, output_info, image_handle) in &args.outputs {
-                let label = output_info.name.as_ref().unwrap();
+            let mut regions = Vec::new();
+            let mut labels = Vec::new();
+            let mut selected = Vec::new();
+            for (output, info, image) in &args.outputs {
+                let (x, y, w, h) = geometry(info);
+                let region = iced::core::Rectangle {
+                    x: (x - min_x) as f32 * scale + GAP / 2.0,
+                    y: (y - min_y) as f32 * scale + GAP / 2.0,
+                    width: (w as f32 * scale - GAP).max(1.0),
+                    height: (h as f32 * scale - GAP).max(1.0),
+                };
                 let is_selected = args.capture_sources.outputs.contains(output);
-                children.push(output_button(
-                    label,
+                children.push(output_thumb_button(
                     is_selected,
-                    image_handle.as_ref(),
+                    image.as_ref(),
+                    region.width,
+                    region.height,
                     Msg::SelectOutput(output.clone()),
                 ));
+                labels.push(info.name.clone().unwrap_or_default());
+                selected.push(is_selected);
+                regions.push(region);
             }
-            widget::row::with_children(children).spacing(8).into()
+
+            let total = iced::core::Size::new(bbox_w * scale, bbox_h * scale);
+            crate::widget::output_arrangement::OutputArrangement::new(
+                children, regions, labels, selected, total,
+            )
+            .into()
         }
         Tab::Windows => {
             let mut list = widget::ListColumn::new();

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -80,6 +80,9 @@ pub async fn show_screencast_prompt(
         outputs.push((output, info, image));
     }
 
+    // Order outputs by their position in the display arrangement
+    outputs.sort_by_key(|(_, info, _)| info.logical_position.unwrap_or((i32::MAX, i32::MAX)));
+
     let app_name = get_desktop_entry(&desktop_entries, &app_id)
         .and_then(|x| Some(x.name(&locales)?.into_owned()));
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1,4 +1,5 @@
 pub mod keyboard_wrapper;
+pub mod output_arrangement;
 pub mod output_selection;
 pub mod rectangle_selection;
 pub mod screenshot;

--- a/src/widget/output_arrangement.rs
+++ b/src/widget/output_arrangement.rs
@@ -1,0 +1,347 @@
+//! A container that places output thumbnails at their position in the display
+//! arrangement (like the cosmic-settings display page), so side-by-side or
+//! stacked screens appear that way. Each child is an ordinary button; this
+//! widget handles their placement and draws a name label over each one.
+
+use cosmic::iced::core::renderer::Quad;
+use cosmic::iced::core::widget::{Operation, Tree, tree};
+use cosmic::iced::core::{
+    self as core, Background, Border, Clipboard, Color, Event, Layout, Length, Pixels, Point,
+    Rectangle, Renderer as _, Shell, Size, Vector, Widget, alignment, layout, mouse, overlay,
+    renderer, text,
+};
+use cosmic::{Element, Renderer};
+
+const LABEL_BAR_MIN: f32 = 14.0;
+const LABEL_BAR_MAX: f32 = 24.0;
+
+pub struct OutputArrangement<'a, Msg> {
+    children: Vec<Element<'a, Msg>>,
+    regions: Vec<Rectangle>,
+    labels: Vec<String>,
+    selected: Vec<bool>,
+    size: Size,
+}
+
+impl<'a, Msg> OutputArrangement<'a, Msg> {
+    /// `regions`, `labels` and `selected` must be parallel to `children`. `size` is
+    /// the total bounding box of all regions.
+    pub fn new(
+        children: Vec<Element<'a, Msg>>,
+        regions: Vec<Rectangle>,
+        labels: Vec<String>,
+        selected: Vec<bool>,
+        size: Size,
+    ) -> Self {
+        Self {
+            children,
+            regions,
+            labels,
+            selected,
+            size,
+        }
+    }
+}
+
+#[derive(Default)]
+struct State {
+    hovered: Option<usize>,
+}
+
+impl<Msg> Widget<Msg, cosmic::Theme, Renderer> for OutputArrangement<'_, Msg> {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::default())
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        self.children.iter().map(Tree::new).collect()
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Fixed(self.size.width),
+            height: Length::Fixed(self.size.height),
+        }
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
+        let regions = &self.regions;
+        let children = self
+            .children
+            .iter_mut()
+            .enumerate()
+            .zip(&mut tree.children)
+            .map(|((i, child), child_tree)| {
+                let region = regions[i];
+                let child_limits = layout::Limits::new(Size::ZERO, region.size());
+                child
+                    .as_widget_mut()
+                    .layout(child_tree, renderer, &child_limits)
+                    .move_to(region.position())
+            })
+            .collect();
+
+        layout::Node::with_children(self.size, children)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &cosmic::Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        for ((child, child_tree), c_layout) in self
+            .children
+            .iter()
+            .zip(&tree.children)
+            .zip(layout.children())
+        {
+            child.as_widget().draw(
+                child_tree,
+                renderer,
+                theme,
+                style,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                viewport,
+            );
+        }
+
+        // Draw highlights and labels in a new layer so they composite above the
+        // thumbnail images. Within a single layer iced always draws quads beneath
+        // images, so without it they hide behind the screenshot.
+        let accent = theme.cosmic().accent_color();
+        let radius = theme.cosmic().radius_s();
+        renderer.with_layer(layout.bounds(), |renderer| {
+            // Highlight the selected output, and the one under the cursor, so it is
+            // clear the thumbnails are clickable.
+            for (c_layout, &is_selected) in layout.children().zip(self.selected.iter()) {
+                let bounds = c_layout.bounds();
+                let hovered = cursor.is_over(bounds);
+                if !is_selected && !hovered {
+                    continue;
+                }
+
+                let mut color = Color::from(accent);
+                let border_width = if is_selected { 3.0 } else { 2.0 };
+                if !is_selected {
+                    color.a = 0.75;
+                }
+
+                renderer.fill_quad(
+                    Quad {
+                        bounds,
+                        border: Border {
+                            color,
+                            width: border_width,
+                            radius: radius.into(),
+                        },
+                        shadow: Default::default(),
+                        snap: true,
+                    },
+                    Background::Color(Color::TRANSPARENT),
+                );
+            }
+
+            for (c_layout, label) in layout.children().zip(self.labels.iter()) {
+                if label.is_empty() {
+                    continue;
+                }
+
+                let bounds = c_layout.bounds();
+                let inset = 4.0;
+                let bar_height = (bounds.height * 0.22)
+                    .clamp(LABEL_BAR_MIN, LABEL_BAR_MAX)
+                    .min(bounds.height - inset);
+                let font_size = (bar_height * 0.62).max(9.0);
+
+                // Size the chip to the text (estimated from its length) rather than
+                // the whole thumbnail, then center it. Clamp to the thumbnail width.
+                let text_width = label.chars().count() as f32 * font_size * 0.55;
+                let bar_width = (text_width + font_size * 1.2).min(bounds.width - inset * 2.0);
+                let bar = Rectangle {
+                    x: bounds.x + (bounds.width - bar_width) / 2.0,
+                    y: bounds.y + bounds.height - bar_height - inset,
+                    width: bar_width.max(1.0),
+                    height: bar_height,
+                };
+
+                // Solid rounded chip so the name is legible over any screenshot.
+                renderer.fill_quad(
+                    Quad {
+                        bounds: bar,
+                        border: Border {
+                            radius: (bar_height / 2.0).into(),
+                            ..Default::default()
+                        },
+                        shadow: Default::default(),
+                        snap: true,
+                    },
+                    Background::Color(Color {
+                        r: 0.0,
+                        g: 0.0,
+                        b: 0.0,
+                        a: 0.85,
+                    }),
+                );
+
+                core::text::Renderer::fill_text(
+                    renderer,
+                    core::Text {
+                        content: label.clone(),
+                        size: Pixels(font_size),
+                        line_height: text::LineHeight::Relative(1.0),
+                        font: cosmic::font::default(),
+                        bounds: bar.size(),
+                        align_x: text::Alignment::Center,
+                        align_y: alignment::Vertical::Center,
+                        shaping: text::Shaping::Advanced,
+                        wrapping: text::Wrapping::None,
+                        ellipsize: text::Ellipsize::None,
+                    },
+                    Point {
+                        x: bar.center_x(),
+                        y: bar.center_y(),
+                    },
+                    Color::WHITE,
+                    bar,
+                );
+            }
+        });
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Msg>,
+        viewport: &Rectangle,
+    ) {
+        for ((child, child_tree), c_layout) in self
+            .children
+            .iter_mut()
+            .zip(&mut tree.children)
+            .zip(layout.children())
+        {
+            child.as_widget_mut().update(
+                child_tree,
+                event,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                renderer,
+                clipboard,
+                shell,
+                viewport,
+            );
+        }
+
+        // Track which thumbnail is hovered and request a redraw when it changes, so
+        // the hover highlight follows the cursor.
+        let hovered = match event {
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                layout.children().position(|l| cursor.is_over(l.bounds()))
+            }
+            Event::Mouse(mouse::Event::CursorLeft) => None,
+            _ => return,
+        };
+        let state = tree.state.downcast_mut::<State>();
+        if state.hovered != hovered {
+            state.hovered = hovered;
+            shell.request_redraw();
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.children
+            .iter()
+            .zip(&tree.children)
+            .zip(layout.children())
+            .map(|((child, child_tree), c_layout)| {
+                child.as_widget().mouse_interaction(
+                    child_tree,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
+                    renderer,
+                )
+            })
+            .max()
+            .unwrap_or_default()
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        operation.container(None, layout.bounds());
+        operation.traverse(&mut |operation| {
+            self.children
+                .iter_mut()
+                .zip(&mut tree.children)
+                .zip(layout.children())
+                .for_each(|((child, state), c_layout)| {
+                    child.as_widget_mut().operate(
+                        state,
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        renderer,
+                        operation,
+                    );
+                });
+        });
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Msg, cosmic::Theme, Renderer>> {
+        overlay::from_children(
+            &mut self.children,
+            tree,
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Msg: 'static> From<OutputArrangement<'a, Msg>> for Element<'a, Msg> {
+    fn from(widget: OutputArrangement<'a, Msg>) -> Self {
+        Element::new(widget)
+    }
+}


### PR DESCRIPTION
This was part of the remote desktop PR, but I took it out to make that one more manageable since this is mostly aesthetics.

When sharing screen, the dialog shows the outputs in a random order, so everytime I have to make sure I'm not sharing the wrong screen in google meet, and when you have 3 monitors with terminals open on all of them, it's not easy!

Before:
<img width="717" height="521" alt="Screenshot_2026-06-18_14-49-16" src="https://github.com/user-attachments/assets/10ff8ac5-5bbd-48ee-aa31-bed035467560" />

The first commit at least sorts the outputs based on their x and then y coords:
<img width="720" height="523" alt="Screenshot_2026-06-18_14-50-04" src="https://github.com/user-attachments/assets/722d9e72-b684-4e0f-8d71-c0bc13c2433c" />

So, if you have all your monitors in a line, you know which is which.
But I also added the output arrangement widget from cosmic-settings to properly show outputs and how they're arranged on your system:

<img width="722" height="483" alt="Screenshot_2026-06-18_16-09-57" src="https://github.com/user-attachments/assets/b8c60729-b04c-4961-8dad-25e764dbf832" />

This correctly shows outputs with random arrangements (one above another, one next to it, etc...).

This may need UI/UX approval.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

