### PR TITLE
fix: honor libexecdir override for binary install path

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ vendor := '0'
 vendor-args := if vendor == '0' { '' } else { '--frozen' }
 
 bin-src := cargo-target-dir / target / name
-bin-dst := base-dir / 'libexec' / name
+bin-dst := absolute_path(clean(rootdir / libexecdir)) / name
 
 [private]
 default: build


### PR DESCRIPTION
fixes a regression for libexecdir overrides introduces in #254  report by a user on Mattermost

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

