### PR TITLE
wayland: don't abort the whole portal on a dead event queue

### DIFF
--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -265,13 +265,30 @@ impl WaylandHelper {
             toplevel_info_state: ToplevelInfoState::new(&registry_state, &qh),
             registry_state,
         };
-        event_queue.flush().unwrap();
+        if let Err(err) = event_queue.flush() {
+            log::error!("Failed initial flush of Wayland event queue: {err}");
+            std::process::exit(1);
+        }
 
-        event_queue.roundtrip(&mut data).unwrap();
+        if let Err(err) = event_queue.roundtrip(&mut data) {
+            log::error!("Failed initial roundtrip of Wayland event queue: {err}");
+            std::process::exit(1);
+        }
 
         thread::spawn(move || {
             loop {
-                event_queue.blocking_dispatch(&mut data).unwrap();
+                if let Err(err) = event_queue.blocking_dispatch(&mut data) {
+                    // The compositor connection is gone (e.g. a client disconnected
+                    // abruptly mid-request, or the compositor itself went away).
+                    // There's nothing more this thread can usefully do with a dead
+                    // connection, so log and exit cleanly instead of panicking the
+                    // whole process (this binary is built with `panic = "abort"`,
+                    // which previously turned any such error into a SIGABRT that
+                    // took down the entire portal, and with it any in-flight
+                    // requests from unrelated clients).
+                    log::error!("Wayland event queue dispatch failed, exiting: {err}");
+                    std::process::exit(1);
+                }
             }
         });
 


### PR DESCRIPTION
## What

Replaces the three `.unwrap()`s in `WaylandHelper::new()` (initial `flush()`, initial `roundtrip()`, and the spawned thread's `blocking_dispatch()` loop) with explicit error handling: log via `log::error!` and `std::process::exit(1)` instead of panicking.

## Why

This crate is built with `panic = "abort"`, so any IO error from those calls — most commonly a client's Wayland connection dying mid-request and the portal receiving `BrokenPipe` — takes down the *entire* portal process with SIGABRT + coredump, not just the affected client's request. Every other client's in-flight portal request dies with it, and it can cascade further depending on timing (on my machine it caused `cosmic-session` to restart `cosmic-comp` in a loop every 1-2 minutes).

Same bug pattern reported in #233, #282, #294, #298 (#298 closed as not-planned — see discussion on #282 for why I still think this is worth doing: the dead connection is genuinely unrecoverable, but the process-wide abort is a bigger blast radius than the failure warrants).

This does not fix the underlying cause of clients disconnecting abruptly (that's app/compositor-side, or the separate `cosmic-session` setsid issue tracked in pop-os/cosmic-session#205) — it just turns an abrupt SIGABRT/coredump into a clean, loggable exit that systemd/dbus activation can restart normally.

## Testing

Built and installed on my own machine (Pop!_OS 24.04, RTX 3080, driver 595.84) in place of the stock binary. Before the fix: `cosmic-comp` was being restarted every 1-2 minutes by `cosmic-session` due to this panic. After: ran continuously with no restarts.

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my contribution under its conditions.
