### PR TITLE
fix: avoid handling panics with an abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,3 @@ cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols//", 
 [profile.release]
 opt-level = 3
 lto = "thin"
-panic = "abort"


### PR DESCRIPTION
Better alternative to #332 which switches the panic handler from `abort` back to `unwind`, which will avoid emitting SIGABRT.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

