### PR TITLE
Fix occasional failure to copy to clipboard

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -69,6 +69,8 @@ pub enum Msg {
     ConfigSetScreenshot(config::screenshot::Screenshot),
     /// Update config from external changes
     ConfigSubUpdate(config::Config),
+    /// A layer surface was closed by the compositor (e.g. output disconnected)
+    LayerClosed(window::Id),
 }
 
 #[derive(Clone, Debug)]
@@ -124,10 +126,10 @@ impl cosmic::Application for CosmicPortal {
             get_layer_surface(SctkLayerSurfaceSettings {
                 id: dummy_id,
                 layer: wlr_layer::Layer::Bottom,
-                keyboard_interactivity: wlr_layer::KeyboardInteractivity::None,
+                keyboard_interactivity: wlr_layer::KeyboardInteractivity::OnDemand,
                 input_zone: Some(Vec::new()),
                 anchor: wlr_layer::Anchor::empty(),
-                output: cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::Active,
+                output: cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::All,
                 namespace: "cosmic_portal_dummy".into(),
                 margin: IcedMargin::default(),
                 size: Some((Some(6), Some(6))),
@@ -280,6 +282,27 @@ impl cosmic::Application for CosmicPortal {
                 self.config = config;
                 cosmic::iced::Task::none()
             }
+            Msg::LayerClosed(id) if id == self.dummy_id => {
+                // The clipboard-owning dummy surface was closed by the compositor
+                // (e.g. an output was disconnected). Re-create it so the portal
+                // always retains a focusable surface to own the clipboard selection.
+                tracing::warn!("Dummy layer surface was closed by compositor, re-creating it");
+                self.dummy_id = window::Id::unique();
+                get_layer_surface(SctkLayerSurfaceSettings {
+                    id: self.dummy_id,
+                    layer: wlr_layer::Layer::Bottom,
+                    keyboard_interactivity: wlr_layer::KeyboardInteractivity::OnDemand,
+                    input_zone: Some(Vec::new()),
+                    anchor: wlr_layer::Anchor::empty(),
+                    output: cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::All,
+                    namespace: "cosmic_portal_dummy".into(),
+                    margin: IcedMargin::default(),
+                    size: Some((Some(6), Some(6))),
+                    exclusive_zone: -1,
+                    size_limits: Limits::NONE,
+                })
+            }
+            Msg::LayerClosed(_) => cosmic::iced::Task::none(),
         }
     }
 
@@ -289,6 +312,9 @@ impl cosmic::Application for CosmicPortal {
             Event::PlatformSpecific(event::PlatformSpecific::Wayland(w_e)) => match w_e {
                 event::wayland::Event::Output(o_event, wl_output) => {
                     Some(Msg::Output(o_event, wl_output))
+                }
+                event::wayland::Event::Layer(event::wayland::LayerEvent::Done, _surface, id) => {
+                    Some(Msg::LayerClosed(id))
                 }
                 _ => None,
             },


### PR DESCRIPTION
I use the same method to copy to clipboard in SnapPea and it never fails, I used cosmic-screenshot a couple of times recently and it kept failing to copy to clipboard.

Comparing the two codebases, I think this is the culprit.
1- Using keyboardInteractivity::None
2- Not recreating the surface if the output goes away

Here's my guess why it happens: You're destroying the layer surface and writing the data in a Task::batch, those surfaces that you're tearing down are the only ones that had keyboard focus, so it's a race. But if you change the dummy surface to OnDemand, it's always valid, so when the UI is being destroyed, that can still hold the seat, and the selection is reliably accepted.

I tested it a bit, I couldn't recreate the issue with this fix. But it could be because I got lucky.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

