### PR TITLE
screencast: honour persist_mode so sessions can be restored without prompting

### DIFF
--- a/examples/screencast.rs
+++ b/examples/screencast.rs
@@ -23,6 +23,32 @@ struct Args {
     multiple: bool,
     #[clap(long, value_enum, value_delimiter(','))]
     source_types: Vec<Source>,
+    /// Ask the portal to remember this selection, so a later session can be
+    /// restored without prompting.
+    #[clap(long, value_enum, default_value("do-not"))]
+    persist_mode: Persist,
+    /// Restore token printed by a previous run. With a valid token the portal
+    /// should start without showing the source picker.
+    #[clap(long)]
+    restore_token: Option<String>,
+}
+
+#[derive(clap::ValueEnum, Debug, Default, Copy, Clone, PartialEq, Eq)]
+enum Persist {
+    #[default]
+    DoNot,
+    Application,
+    ExplicitlyRevoked,
+}
+
+impl From<Persist> for PersistMode {
+    fn from(persist: Persist) -> PersistMode {
+        match persist {
+            Persist::DoNot => PersistMode::DoNot,
+            Persist::Application => PersistMode::Application,
+            Persist::ExplicitlyRevoked => PersistMode::ExplicitlyRevoked,
+        }
+    }
 }
 
 #[derive(clap::ValueEnum, Debug, Copy, Clone, PartialEq, Eq)]
@@ -62,12 +88,18 @@ async fn main() -> anyhow::Result<()> {
             CursorMode::Embedded,
             source_types,
             args.multiple,
-            None,
-            PersistMode::DoNot,
+            args.restore_token.as_deref(),
+            args.persist_mode.into(),
         )
         .await?;
     let streams = screencast.start(&session, None).await?.response()?;
     println!("{} streams", streams.streams().len());
+    // A token only comes back when the portal reports a non-zero persist
+    // mode; without it every reconnect prompts again.
+    match streams.restore_token() {
+        Some(token) => println!("restore_token: {token}"),
+        None => println!("restore_token: <none returned>"),
+    }
     let stream = &streams.streams()[0];
     let fd = screencast.open_pipe_wire_remote(&session).await?;
 

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -143,6 +143,43 @@ struct StartResult {
     restore_data: Option<RestoreData>,
 }
 
+/// How long a granted capture selection survives, per the ScreenCast portal
+/// spec's `persist_mode`.
+///
+/// The value the backend returns from `Start` is what decides whether
+/// xdg-desktop-portal keeps the restore token at all. Reporting `None` makes
+/// the frontend discard it, so the client is prompted again on every
+/// connection even though the restore path here works — which is the usual
+/// complaint from remote-desktop clients.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum PersistMode {
+    /// Do not persist; prompt every time.
+    #[default]
+    None,
+    /// Persist as long as the requesting application is running.
+    Application,
+    /// Persist until the user explicitly revokes it.
+    ExplicitlyRevoked,
+}
+
+impl PersistMode {
+    fn from_request(value: Option<u32>) -> Self {
+        match value {
+            Some(1) => Self::Application,
+            Some(2) => Self::ExplicitlyRevoked,
+            _ => Self::None,
+        }
+    }
+
+    fn as_u32(self) -> u32 {
+        match self {
+            Self::None => 0,
+            Self::Application => 1,
+            Self::ExplicitlyRevoked => 2,
+        }
+    }
+}
+
 #[derive(Default)]
 struct SessionData {
     screencast_threads: Vec<ScreencastThread>,
@@ -150,6 +187,7 @@ struct SessionData {
     multiple: bool,
     source_types: BitFlags<SourceType>,
     persisted_capture_sources: Option<PersistedCaptureSources>,
+    persist_mode: PersistMode,
     closed: bool,
 }
 
@@ -220,6 +258,7 @@ impl ScreenCast {
                     }
                     None => None,
                 };
+                session_data.persist_mode = PersistMode::from_request(options.persist_mode);
                 session_data.multiple = options.multiple.unwrap_or(false);
                 session_data.source_types =
                     BitFlags::from_bits_truncate(options.types.unwrap_or(0));
@@ -256,17 +295,19 @@ impl ScreenCast {
                 return PortalResponse::Other;
             };
 
-            let (cursor_mode, multiple, source_types, persisted_capture_sources) = {
+            let (cursor_mode, multiple, source_types, persisted_capture_sources, persist_mode) = {
                 let session_data = interface.get_mut().await;
                 let cursor_mode = session_data.cursor_mode.unwrap_or(CursorMode::Embedded);
                 let multiple = session_data.multiple;
                 let source_types = session_data.source_types;
                 let persisted_capture_sources = session_data.persisted_capture_sources.clone();
+                let persist_mode = session_data.persist_mode;
                 (
                     cursor_mode,
                     multiple,
                     source_types,
                     persisted_capture_sources,
+                    persist_mode,
                 )
             };
 
@@ -386,10 +427,20 @@ impl ScreenCast {
                 &capture_sources,
             );
 
+            // Only claim persistence when there is actually something to
+            // restore from. Reporting a mode without restore data would have
+            // the frontend keep a token that restores nothing.
+            let restore_data = persisted_capture_sources.map(|x| x.into());
+            let granted_persist_mode = if restore_data.is_some() {
+                persist_mode
+            } else {
+                PersistMode::None
+            };
+
             PortalResponse::Success(StartResult {
                 streams,
-                persist_mode: None,
-                restore_data: persisted_capture_sources.map(|x| x.into()),
+                persist_mode: Some(granted_persist_mode.as_u32()),
+                restore_data,
             })
         })
         .await


### PR DESCRIPTION
# screencast: honour `persist_mode` so sessions can be restored without prompting

## Problem

A client that asks for a persistent ScreenCast session never gets a restore
token back, so it has to prompt for a source again on every connection. Remote
desktop clients hit this constantly — the user grants access, and it looks like
the grant did nothing.

## Cause

The restore path is already implemented and works:

- `select_sources` accepts `restore_data` and stores it on the session
- `start` uses `persisted_capture_sources` to skip the source picker
- `PersistedCaptureSources` round-trips the selection through `RestoreData`

But `start` returns a hardcoded `persist_mode: None`, and
`SelectSourcesOptions::persist_mode` is parsed and never read.

Per the ScreenCast spec that field tells xdg-desktop-portal whether the
selection was persisted. Reporting nothing makes the frontend drop the token,
so the client never gets one, so the restore path never runs.

## Change

- `PersistMode` enum for the spec's `0 | 1 | 2`
- store the requested mode on `SessionData` in `select_sources`
- return it from `start`, only when restore data is actually produced, so the
  frontend never holds a token that restores nothing

## Testing

`examples/screencast.rs` hardcoded `PersistMode::DoNot`, so this path could not
be tested. Added `--persist-mode` and `--restore-token`, and it now prints the
token it gets back.

Before, with `--persist-mode explicitly-revoked`:

```
1 streams
restore_token: <none returned>
```

After:

```
$ cargo run --release --example screencast -- \
      --source-types monitor --persist-mode explicitly-revoked
1 streams
restore_token: 2d947d1d-32e2-401a-b302-9b8ddedd46c4

$ cargo run --release --example screencast -- \
      --source-types monitor --persist-mode explicitly-revoked \
      --restore-token 2d947d1d-32e2-401a-b302-9b8ddedd46c4
1 streams
```

The second run starts streaming with no picker shown. Tested on Pop!_OS 24.04
with two outputs, one rotated, capturing a monitor source.

## Notes

No change to what is captured, to the dialog, or to the permission store. A
client that does not ask for persistence still gets `persist_mode: 0` and is
still prompted.

The requested mode is echoed rather than capped. If you would rather limit what
the backend will grant, that belongs in `start` where the granted mode is
computed.
