### PR TITLE
fix: don't set corner radius on layer surfaces

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -102,6 +102,9 @@ impl cosmic::Application for CosmicPortal {
         }: Self::Flags,
     ) -> (Self, cosmic::iced::Task<cosmic::Action<Self::Message>>) {
         core.set_app_type(cosmic::core::AppType::System);
+        // Rounding our layer surfaces risks a `radius_too_large` protocol error, which kills
+        // the wayland connection shared with `WaylandHelper`
+        core.set_auto_corner_radius(core.auto_corner_radius() & !cosmic::core::Auto::System);
         let dummy_id = window::Id::unique();
         (
             Self {


### PR DESCRIPTION
the theme corner radius is applied to our layer surfaces, and when the compositor's
geometry for a surface is still smaller than twice the radius, it raises the
`radius_too_large` protocol error, which kills the wayland connection now shared with
`WaylandHelper` and takes the process down (so the first screenshot keypress does nothing
and you have to press the key again)

all of our layer surfaces are either invisible (the 6x6 dummy) or cover a whole output, so
rounding them gains nothing

this avoids the trigger rather than fixing the root cause, which is in libcosmic, where
`corners()` applies `radius_s + 4` to any layer surface while `auto_corner_radius` contains
`Auto::System`, and the clamp in iced's `state.rs` compares against iced's own `guard.size`
instead of the compositor's committed geometry, so it misses this race entirely

testing:
1. press the screenshot key repeatedly
2. `journalctl --user -u org.freedesktop.impl.portal.desktop.cosmic` shows no SEGV, where
   the two days before this change logged 25 of them, 24 immediately preceded by
   `cosmic_corner_radius_layer_v1 ... corner radius too large`

- [ ] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
