### PR TITLE
fix: darken area outside screenshot selection

### DIFF
--- a/src/widget/rectangle_selection.rs
+++ b/src/widget/rectangle_selection.rs
@@ -72,6 +72,7 @@ impl From<u8> for DragState {
 
 const EDGE_GRAB_THICKNESS: f32 = 8.0;
 const CORNER_DIAMETER: f32 = 16.0;
+const OVERLAY_ALPHA: f32 = 0.55;
 
 pub struct RectangleSelection<Msg> {
     output_rect: Rect,
@@ -486,63 +487,27 @@ impl<Msg: 'static + Clone> Widget<Msg, cosmic::Theme, cosmic::Renderer>
         );
         let outer_top_left = Point::new(self.output_rect.left as f32, self.output_rect.top as f32);
         let outer_rect = Rectangle::new(outer_top_left, outer_size);
+
+        // dim everything outside the selection, in surface-local coordinates
+        let mut overlay = Color::BLACK;
+        overlay.a = OVERLAY_ALPHA;
+        let dim = |renderer: &mut cosmic::Renderer, bounds: Rectangle| {
+            renderer.fill_quad(
+                Quad {
+                    bounds,
+                    border: Border::default(),
+                    shadow: Shadow::default(),
+                    snap: true,
+                },
+                overlay,
+            );
+        };
+
         let Some(clipped_inner_rect) = inner_rect.intersection(&outer_rect) else {
+            // selection is on another output
+            dim(renderer, Rectangle::with_size(outer_size));
             return;
         };
-        #[cfg(feature = "wgpu")]
-        {
-            use cosmic::iced::advanced::graphics::Mesh;
-            use cosmic::iced::advanced::graphics::color::pack;
-            use cosmic::iced::advanced::graphics::mesh::{Indexed, Renderer, SolidVertex2D};
-            use cosmic::iced::core::Transformation;
-            let mut overlay = Color::BLACK;
-            overlay.a = 0.3;
-
-            let outer_bottom_right = (outer_size.width, outer_size.height);
-            let inner_top_left = (inner_rect.x, inner_rect.y);
-            let outer_top_left = (outer_rect.x, outer_rect.y);
-            let inner_bottom_right = (
-                inner_rect.x + inner_rect.width,
-                inner_rect.y + inner_rect.height,
-            );
-            let vertices = vec![
-                outer_top_left,
-                (outer_bottom_right.0, outer_top_left.1),
-                outer_bottom_right,
-                (outer_top_left.0, outer_bottom_right.1),
-                inner_top_left,
-                (inner_bottom_right.0, inner_top_left.1),
-                inner_bottom_right,
-                (inner_top_left.0, inner_bottom_right.1),
-            ];
-            // build 8 triangles around the selected region
-            #[rustfmt::skip]
-            let indices = vec![
-                5, 2, 1,
-                5, 6, 2,
-                6, 4, 2,
-                6, 8, 4,
-                8, 3, 4,
-                8, 7, 3,
-                7, 1, 3,
-                7, 5, 1,
-            ];
-
-            renderer.draw_mesh(Mesh::Solid {
-                buffers: Indexed {
-                    vertices: vertices
-                        .into_iter()
-                        .map(|v| SolidVertex2D {
-                            position: [v.0, v.1],
-                            color: pack(overlay),
-                        })
-                        .collect(),
-                    indices,
-                },
-                transformation: Transformation::IDENTITY,
-                clip_bounds: Rectangle::INFINITE,
-            })
-        }
 
         let translated_clipped_inner_rect = Rectangle::new(
             Point::new(
@@ -551,6 +516,26 @@ impl<Msg: 'static + Clone> Widget<Msg, cosmic::Theme, cosmic::Renderer>
             ),
             clipped_inner_rect.size(),
         );
+
+        // four bands around the selection: above, below, left and right of it
+        let inner = translated_clipped_inner_rect;
+        let inner_bottom = inner.y + inner.height;
+        let inner_right = inner.x + inner.width;
+        for bounds in [
+            Rectangle::with_size(Size::new(outer_size.width, inner.y)),
+            Rectangle::new(
+                Point::new(0.0, inner_bottom),
+                Size::new(outer_size.width, outer_size.height - inner_bottom),
+            ),
+            Rectangle::new(Point::new(0.0, inner.y), Size::new(inner.x, inner.height)),
+            Rectangle::new(
+                Point::new(inner_right, inner.y),
+                Size::new(outer_size.width - inner_right, inner.height),
+            ),
+        ] {
+            dim(renderer, bounds);
+        }
+
         let quad = Quad {
             bounds: translated_clipped_inner_rect,
             border: Border {


### PR DESCRIPTION
the overlay dimming everything outside the selection sat inside a `#[cfg(feature = "wgpu")]` block, and since `wgpu` is not a default feature and the justfile builds without it, the dimming was compiled out of every packaged build

this replaces the mesh with four quads so it works under `tiny_skia` as well, which also drops the meshs out of range indices (the 8 vertex array was indexed 1..8 rather than 0..7)

outputs the selection does not touch are now dimmed fully instead of hitting an early return, which i believe matters on multi monitor setups

the alpha is 0.55 where the mesh used 0.3, so this is darker as well as actually visible

side note: with the mesh gone, `grep -rn wgpu src/` is empty, so the `wgpu` feature only forwards to `libcosmic/wgpu`, which Cargo.toml already enables unconditionally (happy to remove the feature and its ci matrix row in a follow-up if you want it gone)

testing:
1. press the screenshot key and drag a selection
2. everything outside the selection is dimmed

<img width="482" height="253" alt="screenshot" src="https://github.com/user-attachments/assets/d12eebbf-aeaa-4477-a8b3-4b1b47105068" />

- [ ] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.