### PR TITLE
screenshot: Fix overlay setup and clipboard handoff races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9227,6 +9227,7 @@ dependencies = [
  "dirs 6.0.0",
  "futures",
  "gbm",
+ "getrandom 0.3.4",
  "gstreamer",
  "i18n-embed",
  "i18n-embed-fl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ cosmic-files = { git = "https://github.com/pop-os/cosmic-files", default-feature
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "32283d7" }
 cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols", rev = "32283d7" }
 futures = "0.3"
+getrandom = "0.3"
 image = "0.25"
 cosmic-bg-config = { git = "https://github.com/pop-os/cosmic-bg" }
 cosmic-portal-config = { path = "./cosmic-portal-config" }
@@ -52,7 +53,7 @@ serde.workspace = true
 spa_sys = { package = "libspa-sys", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
 pipewire-sys = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs" }
 tempfile = "3.27.0"
-tokio = { version = "1.52.1", features = ["macros", "net", "rt", "sync"] }
+tokio = { version = "1.52.1", features = ["macros", "net", "rt", "sync", "time"] }
 wayland-client = { version = "0.31.14" }
 tracing = "0.1.44"
 tracing-journald = { version = "0.3.2", optional = true }

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,6 +35,8 @@ pub struct CosmicPortal {
     pub file_choosers: HashMap<window::Id, (file_chooser::Args, file_chooser::Dialog)>,
 
     pub screenshot_args: Option<screenshot::Args>,
+    pub screenshot_clipboard_in_flight: Option<u64>,
+    pub screenshot_generation: u64,
     pub screencast_args: Option<screencast_dialog::Args>,
     pub screencast_tab_model:
         widget::segmented_button::Model<widget::segmented_button::SingleSelect>,
@@ -111,6 +113,8 @@ impl cosmic::Application for CosmicPortal {
                 access_args: Default::default(),
                 file_choosers: Default::default(),
                 screenshot_args: Default::default(),
+                screenshot_clipboard_in_flight: None,
+                screenshot_generation: 0,
                 screencast_args: Default::default(),
                 screencast_tab_model: Default::default(),
                 location_options: Vec::new(),

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -957,7 +957,14 @@ pub fn update_args(
                     let name = name.clone();
                     cosmic::surface::surface_task::<crate::app::Msg>(
                 cosmic::surface::action::simple_layer_shell::<crate::app::Msg>(
-                    Default::default,
+                    || cosmic::surface::action::LiveSettings {
+                        // Screenshot overlays cover the entire output, so surface-level rounded
+                        // corners are unnecessary. Explicit zero radii also remain valid before
+                        // the layer receives its configured size; a nonzero radius that exceeds
+                        // half the temporary dimensions is a fatal corner-radius protocol error.
+                        corners: Some(Default::default()),
+                        ..Default::default()
+                    },
                         move || {
                             SctkLayerSurfaceSettings {
                                     id,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -2,6 +2,7 @@
 
 use cosmic::cosmic_config::CosmicConfigEntry;
 use cosmic::iced::clipboard::mime::AsMimeTypes;
+use cosmic::iced::core::clipboard::Kind;
 use cosmic::iced::keyboard::Key;
 use cosmic::iced::keyboard::key::Named;
 use cosmic::iced::platform_specific::shell::commands::layer_surface::destroy_layer_surface;
@@ -20,6 +21,8 @@ use std::collections::HashMap;
 use std::io;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Sender;
 
 use wayland_client::protocol::wl_output::WlOutput;
@@ -76,23 +79,64 @@ pub struct ScreenshotResult {
     uri: String,
 }
 
-struct ScreenshotBytes {
-    bytes: Vec<u8>,
+const SCREENSHOT_MIME_TYPE: &str = "image/png";
+const CLIPBOARD_VERIFY_MIME_PREFIX: &str = "application/x-cosmic-screenshot-verification";
+// Bounds retries between completed marker reads. The clipboard backend does not
+// currently expose a cancelable read operation.
+const CLIPBOARD_VERIFY_RETRY_WINDOW: Duration = Duration::from_millis(500);
+const CLIPBOARD_WRITE_RETRY_DELAY: Duration = Duration::from_millis(10);
+const CLIPBOARD_WRITE_MAX_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+#[derive(Clone)]
+pub(crate) struct ScreenshotBytes {
+    bytes: Arc<[u8]>,
+    marker: [u8; 16],
+    verification_mime: String,
 }
 
 impl ScreenshotBytes {
-    fn new(bytes: Vec<u8>) -> Self {
-        Self { bytes }
+    fn new(bytes: Vec<u8>) -> Option<Self> {
+        let mut marker = [0; 16];
+        if let Err(err) = getrandom::fill(&mut marker) {
+            tracing::error!("Failed to create screenshot clipboard marker: {err}");
+            return None;
+        }
+        let verification_mime = format!(
+            "{CLIPBOARD_VERIFY_MIME_PREFIX}-{:032x}",
+            u128::from_ne_bytes(marker)
+        );
+        Some(Self {
+            bytes: bytes.into(),
+            marker,
+            verification_mime,
+        })
+    }
+}
+
+impl std::fmt::Debug for ScreenshotBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScreenshotBytes")
+            .field("len", &self.bytes.len())
+            .finish()
     }
 }
 
 impl AsMimeTypes for ScreenshotBytes {
     fn available(&self) -> std::borrow::Cow<'static, [String]> {
-        Cow::Owned(vec!["image/png".to_string()])
+        Cow::Owned(vec![
+            SCREENSHOT_MIME_TYPE.to_string(),
+            self.verification_mime.clone(),
+        ])
     }
 
     fn as_bytes(&self, mime_type: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
-        Some(Cow::Owned(self.bytes.clone()))
+        if mime_type == SCREENSHOT_MIME_TYPE {
+            Some(Cow::Owned(self.bytes.to_vec()))
+        } else if mime_type == self.verification_mime {
+            Some(Cow::Owned(self.marker.to_vec()))
+        } else {
+            None
+        }
     }
 }
 
@@ -377,11 +421,68 @@ fn write_png<W: io::Write>(w: W, image: &RgbaImage) -> Result<(), png::EncodingE
 pub enum Msg {
     Capture,
     CaptureWithLocation(ImageSaveLocation),
+    ClipboardWritten {
+        data: ScreenshotBytes,
+        actual: Option<Vec<u8>>,
+        response: Option<(Sender<PortalResponse<ScreenshotResult>>, String)>,
+        attempt: u8,
+        retry_deadline: Instant,
+        generation: u64,
+        layer_ids: Vec<window::Id>,
+    },
     Cancel,
     Choice(Choice),
     OutputChanged(WlOutput),
     WindowChosen(String, usize),
     Location(usize),
+}
+
+fn read_clipboard_marker(mime_type: String) -> cosmic::Task<Option<Vec<u8>>> {
+    // The per-capture MIME type cannot match an unrelated previous selection,
+    // so a read attempted before our queued write becomes current fails without
+    // requesting that selection's potentially large payload.
+    cosmic::iced::runtime::task::oneshot(move |tx| {
+        cosmic::iced::runtime::Action::Clipboard(clipboard::Action::ReadData(
+            vec![mime_type],
+            tx,
+            Kind::Standard,
+        ))
+    })
+    .map(|data| data.map(|(bytes, _mime_type)| bytes))
+}
+
+fn write_clipboard_and_verify(
+    data: ScreenshotBytes,
+    response: Option<(Sender<PortalResponse<ScreenshotResult>>, String)>,
+    attempt: u8,
+    retry_deadline: Instant,
+    generation: u64,
+    layer_ids: Vec<window::Id>,
+) -> cosmic::Task<cosmic::Action<crate::app::Msg>> {
+    let verification_data = data.clone();
+    let verification_mime = data.verification_mime.clone();
+    let retry_delay = CLIPBOARD_WRITE_RETRY_DELAY
+        .saturating_mul(2_u32.saturating_pow(u32::from(attempt)))
+        .min(CLIPBOARD_WRITE_MAX_RETRY_DELAY);
+    clipboard::write_data(data)
+        // `write_data` only queues work for smithay-clipboard. Give its separate
+        // Wayland connection a chance to observe keyboard focus and install the
+        // selection before asking it to read the selection back.
+        .chain(cosmic::Task::perform(
+            tokio::time::sleep(retry_delay),
+            |_| cosmic::action::none(),
+        ))
+        .chain(read_clipboard_marker(verification_mime).map(move |actual| {
+            cosmic::action::app(crate::app::Msg::Screenshot(Msg::ClipboardWritten {
+                data: verification_data.clone(),
+                actual,
+                response: response.clone(),
+                attempt,
+                retry_deadline,
+                generation,
+                layer_ids: layer_ids.clone(),
+            }))
+        }))
 }
 
 #[derive(Debug, Clone)]
@@ -650,14 +751,19 @@ pub fn update_msg(
 ) -> cosmic::Task<cosmic::Action<crate::app::Msg>> {
     match msg {
         Msg::Capture => {
-            let mut cmds: Vec<cosmic::Task<cosmic::Action<crate::app::Msg>>> = portal
-                .outputs
+            if portal.screenshot_clipboard_in_flight.is_some() {
+                tracing::debug!("Ignoring duplicate capture during clipboard verification");
+                return cosmic::Task::none();
+            }
+            let layer_ids: Vec<_> = portal.outputs.iter().map(|output| output.id).collect();
+            let close_tasks: Vec<cosmic::Task<cosmic::Action<crate::app::Msg>>> = layer_ids
                 .iter()
-                .map(|o| destroy_layer_surface(o.id))
+                .copied()
+                .map(destroy_layer_surface)
                 .collect();
             let Some(args) = portal.screenshot_args.take() else {
                 tracing::error!("Failed to find screenshot Args for Capture message.");
-                return cosmic::Task::batch(cmds);
+                return cosmic::Task::batch(close_tasks);
             };
             let outputs = portal.outputs.clone();
             let Args {
@@ -670,6 +776,7 @@ pub fn update_msg(
 
             let mut success = true;
             let image_path = Screenshot::get_img_path(location);
+            let mut clipboard_data = None;
 
             match choice {
                 Choice::Output(name) => {
@@ -680,7 +787,8 @@ pub fn update_msg(
                                 success = false;
                             })
                         {
-                            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
+                            clipboard_data = ScreenshotBytes::new(buffer);
+                            success = clipboard_data.is_some() || image_path.is_some();
                         }
                     } else {
                         tracing::error!("Failed to find output {}", name);
@@ -718,7 +826,8 @@ pub fn update_msg(
                                 success = false;
                             })
                         {
-                            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
+                            clipboard_data = ScreenshotBytes::new(buffer);
+                            success = clipboard_data.is_some() || image_path.is_some();
                         }
                     } else {
                         success = false;
@@ -736,7 +845,8 @@ pub fn update_msg(
                                 success = false;
                             })
                         {
-                            cmds.push(clipboard::write_data(ScreenshotBytes::new(buffer)));
+                            clipboard_data = ScreenshotBytes::new(buffer);
+                            success = clipboard_data.is_some() || image_path.is_some();
                         }
                     } else {
                         success = false;
@@ -747,24 +857,58 @@ pub fn update_msg(
                 }
             }
 
-            let response = if success && let Some(image_path) = image_path {
-                PortalResponse::Success(ScreenshotResult {
+            if success && let Some(data) = clipboard_data {
+                let response = if let Some(image_path) = image_path {
+                    let response = PortalResponse::Success(ScreenshotResult {
+                        uri: format!("file:///{}", image_path.display()),
+                    });
+                    tokio::spawn(async move {
+                        if let Err(err) = tx.send(response).await {
+                            tracing::error!("Failed to send screenshot event: {err}");
+                        }
+                    });
+                    None
+                } else {
+                    Some((tx, "clipboard:///".to_string()))
+                };
+
+                // smithay-clipboard stores data on a separate Wayland connection and silently
+                // skips the write if that connection has not observed keyboard focus. Keep the
+                // screenshot layers focused until the compositor offers our per-capture marker;
+                // only then is it safe to report clipboard success and close the layers.
+                let generation = portal.screenshot_generation;
+                portal.screenshot_clipboard_in_flight = Some(generation);
+                return write_clipboard_and_verify(
+                    data,
+                    response,
+                    0,
+                    Instant::now() + CLIPBOARD_VERIFY_RETRY_WINDOW,
+                    generation,
+                    layer_ids,
+                );
+            }
+
+            if success && let Some(image_path) = image_path {
+                tracing::warn!(
+                    "Screenshot saved without a clipboard copy: failed to create verification marker"
+                );
+                let response = PortalResponse::Success(ScreenshotResult {
                     uri: format!("file:///{}", image_path.display()),
-                })
-            } else if success && image_path.is_none() {
-                PortalResponse::Success(ScreenshotResult {
-                    uri: "clipboard:///".to_string(),
-                })
-            } else {
-                PortalResponse::Other
-            };
+                });
+                tokio::spawn(async move {
+                    if let Err(err) = tx.send(response).await {
+                        tracing::error!("Failed to send screenshot event: {err}");
+                    }
+                });
+                return cosmic::Task::batch(close_tasks);
+            }
 
             tokio::spawn(async move {
-                if let Err(err) = tx.send(response).await {
-                    tracing::error!("Failed to send screenshot event");
+                if let Err(err) = tx.send(PortalResponse::Other).await {
+                    tracing::error!("Failed to send screenshot event: {err}");
                 }
             });
-            cosmic::Task::batch(cmds)
+            cosmic::Task::batch(close_tasks)
         }
         Msg::CaptureWithLocation(location) => {
             if let Some(args) = portal.screenshot_args.as_mut() {
@@ -775,7 +919,84 @@ pub fn update_msg(
             }
             update_msg(portal, Msg::Capture)
         }
+        Msg::ClipboardWritten {
+            data,
+            actual,
+            response,
+            attempt,
+            retry_deadline,
+            generation,
+            layer_ids,
+        } => {
+            if portal.screenshot_clipboard_in_flight != Some(generation) {
+                tracing::warn!(
+                    generation,
+                    "Ignoring stale screenshot clipboard verification"
+                );
+                if let Some((tx, _uri)) = response {
+                    tokio::spawn(async move {
+                        if let Err(err) = tx.send(PortalResponse::Other).await {
+                            tracing::error!("Failed to send screenshot event: {err}");
+                        }
+                    });
+                }
+                return cosmic::Task::none();
+            }
+
+            if actual.is_some_and(|actual| actual.as_slice() == data.marker) {
+                portal.screenshot_clipboard_in_flight = None;
+                if let Some((tx, uri)) = response {
+                    tokio::spawn(async move {
+                        let response = PortalResponse::Success(ScreenshotResult { uri });
+                        if let Err(err) = tx.send(response).await {
+                            tracing::error!("Failed to send screenshot event: {err}");
+                        }
+                    });
+                }
+                let close_tasks = layer_ids.into_iter().map(destroy_layer_surface);
+                cosmic::Task::batch(close_tasks)
+            } else if Instant::now() < retry_deadline {
+                tracing::debug!(
+                    attempt,
+                    "Screenshot clipboard verification failed; retrying"
+                );
+                write_clipboard_and_verify(
+                    data,
+                    response,
+                    attempt.saturating_add(1),
+                    retry_deadline,
+                    generation,
+                    layer_ids,
+                )
+            } else {
+                portal.screenshot_clipboard_in_flight = None;
+                if response.is_some() {
+                    tracing::error!(
+                        attempt,
+                        "Failed to verify screenshot clipboard contents; not reporting success"
+                    );
+                } else {
+                    tracing::warn!(
+                        attempt,
+                        "Screenshot was saved, but its clipboard copy could not be verified"
+                    );
+                }
+                if let Some((tx, _uri)) = response {
+                    tokio::spawn(async move {
+                        if let Err(err) = tx.send(PortalResponse::Other).await {
+                            tracing::error!("Failed to send screenshot event: {err}");
+                        }
+                    });
+                }
+                let close_tasks = layer_ids.into_iter().map(destroy_layer_surface);
+                cosmic::Task::batch(close_tasks)
+            }
+        }
         Msg::Cancel => {
+            if portal.screenshot_clipboard_in_flight.is_some() {
+                tracing::debug!("Ignoring cancel during clipboard verification");
+                return cosmic::Task::none();
+            }
             let cmds = portal.outputs.iter().map(|o| destroy_layer_surface(o.id));
             let Some(args) = portal.screenshot_args.take() else {
                 tracing::error!("Failed to find screenshot Args for Cancel message.");
@@ -885,6 +1106,21 @@ pub fn update_args(
     portal: &mut CosmicPortal,
     args: Args,
 ) -> cosmic::Task<cosmic::Action<crate::app::Msg>> {
+    if let Some(generation) = portal.screenshot_clipboard_in_flight {
+        tracing::warn!(
+            generation,
+            "Rejecting screenshot request while clipboard verification is in flight"
+        );
+        let tx = args.tx.clone();
+        tokio::spawn(async move {
+            if let Err(err) = tx.send(PortalResponse::Other).await {
+                tracing::error!("Failed to send screenshot event: {err}");
+            }
+        });
+        return cosmic::Task::none();
+    }
+    portal.screenshot_generation = portal.screenshot_generation.wrapping_add(1);
+
     let Args {
         handle,
         app_id,


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

- Use zero surface corner radii for full-output screenshot layers so their temporary pre-configure size always satisfies the compositor protocol.
- Keep screenshot layers alive until the compositor offers a unique per-capture verification MIME type from the queued clipboard write.
- Retry ordinary focus-handoff failures within a bounded retry window and do not report `clipboard:///` success when ownership cannot be verified.
- Apply the verified handoff to the existing always-copy behavior while keeping successful file-save responses independent.
- Reject overlapping screenshot requests while clipboard verification is in flight.

Fixes #310.

This also addresses the screenshot-specific selection-drop behavior reported in #295. The unsymbolized crash in #316 is related, but this PR does not claim to resolve every possible cause of that report.

## Root cause and findings

The screenshot overlay inherited automatic theme corner radii. A nonzero radius could be sent before the layer received its full output dimensions, allowing the compositor to reject a radius larger than half the temporary surface size and terminate the shared Wayland connection.

Separately, `write_data` queues work for smithay-clipboard on another Wayland connection; completion of that task is not confirmation that the selection was installed. The portal destroyed its focused screenshot layers and returned success before the worker necessarily observed keyboard focus and set the selection. Depending on scheduling, the previous selection could therefore disappear while the portal still reported success.

The change uses zero surface radii and offers a random 128-bit marker under a per-capture MIME type. The portal keeps the layers focused and retries the write until that exact 16-byte marker can be read through the compositor. An unrelated previous selection cannot match the random MIME type, so verification does not read its payload.

The retry window bounds retries between completed reads; it is not a hard timeout for the clipboard backend because the current iced/window_clipboard API does not expose a cancelable read.

## Relationship to earlier changes

#319 addresses stale screenshot output state, while #320 addresses subscription recovery. The later merged #337 adds systemd service integration and recovery after a Wayland thread failure. Those changes can prevent or recover other failure modes, but none serializes this clipboard handoff or constrains overlay corners before configure. This pull request is independent and neither includes nor replaces them.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --no-default-features`
- `cargo check --features wgpu`
- `cargo build --release --locked`
- 31/31 accepted clipboard captures across manual, steady-state, paced fresh-service-start, and final deployed-binary smoke tests, alternating Return and Ctrl+C where applicable.
- Verified that each accepted clipboard offered `image/png` and that its PNG stream decoded successfully.
- Verified zero automatic service restarts and no clipboard-verification, corner-radius protocol, panic, segmentation-fault, or coredump errors after the final deployment.

`cargo test --all-features` could not complete locally because the test-only `gstreamer-sys` build could not find `gstreamer-1.0.pc`. The upstream test job installs `libgstreamer1.0-dev`. Clippy is not installed in the local toolchain; the upstream CI job provisions it.

PNG data was streamed directly from the clipboard to a metadata decoder. No screenshot or diagnostic-log files are attached or retained.

## AI assistance disclosure

This pull request was prepared with OpenAI Codex and reviewed, understood, and tested by the submitter before submission.
