### PR TITLE
improv: use checkboxes and radiobuttons to indicate multi/single source

### DIFF
--- a/src/remote_desktop_dialog.rs
+++ b/src/remote_desktop_dialog.rs
@@ -401,6 +401,7 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
             &args.outputs,
             &args.toplevels,
             &args.capture_sources,
+            args.multiple,
             Msg::ActivateTab,
             Msg::SelectOutput,
             Msg::SelectToplevel,

--- a/src/screencast_dialog.rs
+++ b/src/screencast_dialog.rs
@@ -270,11 +270,13 @@ pub(crate) fn update_tab_model(
 /// outputs laid out by display arrangement or the list of windows. Generic over
 /// the dialog's message type so both the screencast and remote-desktop dialogs
 /// can reuse it.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn sources_view<'a, M, FTab, FOut, FTop>(
     tab_model: &'a widget::segmented_button::Model<widget::segmented_button::SingleSelect>,
     outputs: &'a [(WlOutput, OutputInfo, Option<widget::image::Handle>)],
     toplevels: &'a [(ToplevelInfo, Option<String>)],
     selected: &'a CaptureSources,
+    multiple: bool,
     on_tab: FTab,
     on_output: FOut,
     on_toplevel: FTop,
@@ -350,7 +352,8 @@ where
                 labels,
                 selected_flags,
                 total,
-            );
+            )
+            .multiple(multiple);
             widget::container(arrangement)
                 .width(iced::Length::Fill)
                 .align_x(iced::Alignment::Center)
@@ -365,6 +368,7 @@ where
                 list = list.add(toplevel_button(
                     label,
                     is_selected,
+                    multiple,
                     icon,
                     on_toplevel(toplevel_info.foreign_toplevel.clone()),
                 ));
@@ -494,11 +498,13 @@ fn output_thumb_button<'a, M: Clone + 'static>(
     height: f32,
     msg: M,
 ) -> cosmic::Element<'a, M> {
+    let radius = cosmic::theme::active().cosmic().radius_s();
     let content: cosmic::Element<'a, M> = match image_handle {
         Some(image_handle) => widget::image::Image::new(image_handle.clone())
             .width(iced::Length::Fill)
             .height(iced::Length::Fill)
             .content_fit(iced::ContentFit::Fill)
+            .border_radius(radius)
             .into(),
         None => widget::container(widget::text(""))
             .width(iced::Length::Fill)
@@ -530,6 +536,7 @@ fn output_thumb_button<'a, M: Clone + 'static>(
 fn toplevel_button<'a, M: Clone + 'static>(
     label: &'a str,
     is_selected: bool,
+    multiple: bool,
     icon: IconSource,
     msg: M,
 ) -> cosmic::Element<'a, M> {
@@ -540,22 +547,22 @@ fn toplevel_button<'a, M: Clone + 'static>(
             ..Default::default()
         }
     }));
-    let button = widget::button::custom(text)
+    let content = widget::row::with_children(vec![
+        crate::widget::selection_indicator::SelectionIndicator::new(is_selected, multiple).into(),
+        icon.as_cosmic_icon().icon().size(24).into(),
+        text.into(),
+    ])
+    .spacing(12)
+    .align_y(iced::Alignment::Center);
+    widget::button::custom(content)
         .width(iced::Length::Fill)
         .padding(0)
         // TODO hover style? Etc.
         // .style(theme::style::Button::Text)
         .class(theme::style::Button::Transparent)
         .selected(is_selected)
-        .on_press(msg);
-    let mut children = Vec::new();
-    children.push(icon.as_cosmic_icon().icon().size(24).into());
-    children.push(button.into());
-    // TODO
-    if is_selected {
-        children.push(widget::text("✓").into());
-    }
-    widget::row::with_children(children).spacing(12).into()
+        .on_press(msg)
+        .into()
 }
 
 pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
@@ -579,6 +586,7 @@ pub(crate) fn view(portal: &CosmicPortal) -> cosmic::Element<'_, Msg> {
         &args.outputs,
         &args.toplevels,
         &args.capture_sources,
+        args.multiple,
         Msg::ActivateTab,
         Msg::SelectOutput,
         Msg::SelectToplevel,

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -3,3 +3,4 @@ pub mod output_arrangement;
 pub mod output_selection;
 pub mod rectangle_selection;
 pub mod screenshot;
+pub mod selection_indicator;

--- a/src/widget/output_arrangement.rs
+++ b/src/widget/output_arrangement.rs
@@ -13,6 +13,8 @@ use cosmic::iced::core::{
 };
 use cosmic::{Element, Renderer};
 
+const FOCUS_GAP: f32 = 2.0;
+const FOCUS_WIDTH: f32 = 1.0;
 const LABEL_BAR_MIN: f32 = 14.0;
 const LABEL_BAR_MAX: f32 = 24.0;
 
@@ -23,6 +25,7 @@ pub struct OutputArrangement<'a, Msg> {
     labels: Vec<String>,
     selected: Vec<bool>,
     size: Size,
+    multiple: bool,
 }
 
 impl<'a, Msg> OutputArrangement<'a, Msg> {
@@ -44,7 +47,15 @@ impl<'a, Msg> OutputArrangement<'a, Msg> {
             labels,
             selected,
             size,
+            multiple: false,
         }
+    }
+
+    /// Mark the outputs with checkboxes rather than radio buttons, for when the
+    /// app accepts more than one source.
+    pub fn multiple(mut self, multiple: bool) -> Self {
+        self.multiple = multiple;
+        self
     }
 }
 
@@ -189,23 +200,23 @@ impl<Msg: Clone> Widget<Msg, cosmic::Theme, Renderer> for OutputArrangement<'_, 
                 );
             }
 
-            // Focus ring for the keyboard-focused output, inset so it reads as
-            // distinct from the selection border.
+            // Focus ring for the keyboard-focused output. Outside the thumbnail,
+            // as a focused button draws it
             if let Some(c_layout) = focused.and_then(|index| layout.children().nth(index)) {
                 let bounds = c_layout.bounds();
-                let inset = 3.0;
+                let offset = FOCUS_GAP + FOCUS_WIDTH;
                 let ring = Rectangle {
-                    x: bounds.x + inset,
-                    y: bounds.y + inset,
-                    width: (bounds.width - inset * 2.0).max(1.0),
-                    height: (bounds.height - inset * 2.0).max(1.0),
+                    x: bounds.x - offset,
+                    y: bounds.y - offset,
+                    width: bounds.width + offset * 2.0,
+                    height: bounds.height + offset * 2.0,
                 };
                 renderer.fill_quad(
                     Quad {
                         bounds: ring,
                         border: Border {
                             color: Color::from(accent),
-                            width: 2.0,
+                            width: FOCUS_WIDTH,
                             radius: radius.into(),
                         },
                         shadow: Default::default(),
@@ -277,6 +288,16 @@ impl<Msg: Clone> Widget<Msg, cosmic::Theme, Renderer> for OutputArrangement<'_, 
                     },
                     Color::WHITE,
                     bar,
+                );
+            }
+
+            for (c_layout, &is_selected) in layout.children().zip(self.selected.iter()) {
+                crate::widget::selection_indicator::draw_badge(
+                    renderer,
+                    theme,
+                    c_layout.bounds(),
+                    is_selected,
+                    self.multiple,
                 );
             }
         });

--- a/src/widget/selection_indicator.rs
+++ b/src/widget/selection_indicator.rs
@@ -1,0 +1,216 @@
+//! The badge that marks a capture source as selectable and selected
+
+use cosmic::iced::core::widget::Tree;
+use cosmic::iced::core::{
+    Background, Border, Color, Layout, Length, Rectangle, Renderer as _, Size, Widget, layout,
+    mouse, renderer, svg,
+};
+use cosmic::widget::button::Catalog as _;
+use cosmic::{Element, Renderer};
+use std::sync::LazyLock;
+
+/// Chip behind the mark, sized as in libcosmic's image button.
+const CHIP: Size = Size::new(24.0, 20.0);
+/// The mark itself: a check icon, or an empty box or circle.
+const MARK: f32 = 16.0;
+/// Keeps the badge clear of the thumbnail's selection border.
+const INSET: f32 = 3.0;
+/// Dot inside a selected radio button, in libcosmic's 6-in-20 proportion.
+const DOT: f32 = MARK * 0.3;
+
+static OBJECT_SELECT: LazyLock<svg::Handle> = LazyLock::new(|| {
+    cosmic::widget::icon::from_name("object-select-symbolic")
+        .size(MARK as u16)
+        .icon()
+        .into_svg_handle()
+        .unwrap_or_else(|| {
+            let bytes: &'static [u8] = &[];
+            svg::Handle::from_memory(bytes)
+        })
+});
+
+/// Draw the badge in the top left of `thumbnail`. Top, because output
+/// thumbnails carry their name along the bottom.
+pub fn draw_badge(
+    renderer: &mut Renderer,
+    theme: &cosmic::Theme,
+    thumbnail: Rectangle,
+    selected: bool,
+    multiple: bool,
+) {
+    // Never scale with the thumbnail
+    if thumbnail.width < CHIP.width * 2.0 || thumbnail.height < CHIP.height * 2.0 {
+        return;
+    }
+
+    let radius = theme.cosmic().radius_s();
+    let chip = Rectangle {
+        x: thumbnail.x + INSET,
+        y: thumbnail.y + INSET,
+        width: CHIP.width,
+        height: CHIP.height,
+    };
+
+    renderer.fill_quad(
+        renderer::Quad {
+            bounds: chip,
+            border: Border {
+                radius: [radius[0], 0.0, radius[2], 0.0].into(),
+                ..Default::default()
+            },
+            shadow: Default::default(),
+            snap: true,
+        },
+        theme.selection_background(),
+    );
+
+    draw_mark(
+        renderer,
+        theme,
+        Rectangle {
+            x: chip.center_x() - MARK / 2.0,
+            y: chip.center_y() - MARK / 2.0,
+            width: MARK,
+            height: MARK,
+        },
+        selected,
+        multiple,
+    );
+}
+
+fn draw_mark(
+    renderer: &mut Renderer,
+    theme: &cosmic::Theme,
+    bounds: Rectangle,
+    selected: bool,
+    multiple: bool,
+) {
+    let cosmic = theme.cosmic();
+
+    if multiple {
+        if selected {
+            let icon =
+                svg::Svg::new(OBJECT_SELECT.clone()).color(Color::from(cosmic.accent_color()));
+            svg::Renderer::draw_svg(renderer, icon, bounds, bounds);
+        } else {
+            draw_outline(renderer, bounds, cosmic.radius_xs(), cosmic);
+        }
+        return;
+    }
+
+    if !selected {
+        draw_outline(renderer, bounds, [MARK / 2.0; 4], cosmic);
+        return;
+    }
+
+    renderer.fill_quad(
+        renderer::Quad {
+            bounds,
+            border: Border {
+                radius: (MARK / 2.0).into(),
+                ..Default::default()
+            },
+            shadow: Default::default(),
+            snap: true,
+        },
+        Background::Color(Color::from(cosmic.accent_color())),
+    );
+    renderer.fill_quad(
+        renderer::Quad {
+            bounds: Rectangle {
+                x: bounds.center_x() - DOT / 2.0,
+                y: bounds.center_y() - DOT / 2.0,
+                width: DOT,
+                height: DOT,
+            },
+            border: Border {
+                radius: (DOT / 2.0).into(),
+                ..Default::default()
+            },
+            shadow: Default::default(),
+            snap: true,
+        },
+        Background::Color(Color::from(cosmic.on_accent_color())),
+    );
+}
+
+/// An empty box or circle
+fn draw_outline(
+    renderer: &mut Renderer,
+    bounds: Rectangle,
+    radius: [f32; 4],
+    cosmic: &cosmic::cosmic_theme::Theme,
+) {
+    let mut color = Color::from(cosmic.on_primary_container_color());
+    color.a *= 0.7;
+
+    renderer.fill_quad(
+        renderer::Quad {
+            bounds,
+            border: Border {
+                color,
+                width: 1.5,
+                radius: radius.into(),
+            },
+            shadow: Default::default(),
+            snap: true,
+        },
+        Background::Color(Color::TRANSPARENT),
+    );
+}
+
+/// The mark on its own, without the chip, for laying out beside a label
+/// whatever contains it is responsible for the click.
+pub struct SelectionIndicator {
+    selected: bool,
+    multiple: bool,
+}
+
+impl SelectionIndicator {
+    pub fn new(selected: bool, multiple: bool) -> Self {
+        Self { selected, multiple }
+    }
+}
+
+impl<Msg> Widget<Msg, cosmic::Theme, Renderer> for SelectionIndicator {
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Fixed(MARK),
+            height: Length::Fixed(MARK),
+        }
+    }
+
+    fn layout(
+        &mut self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
+        layout::Node::new(Size::new(MARK, MARK))
+    }
+
+    fn draw(
+        &self,
+        _tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &cosmic::Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+        draw_mark(
+            renderer,
+            theme,
+            layout.bounds(),
+            self.selected,
+            self.multiple,
+        );
+    }
+}
+
+impl<'a, Msg: 'a> From<SelectionIndicator> for Element<'a, Msg> {
+    fn from(indicator: SelectionIndicator) -> Self {
+        Element::new(indicator)
+    }
+}


### PR DESCRIPTION
This PR contains the UI improvements I mentioned [here with its demo video](https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/317#issuecomment-5334971197).

This also improves drawing of the tab focus hint, so it's easier to tell when your pressing tab to move between the outputs and pressing space to select.

Single source:
<img width="737" height="637" alt="image" src="https://github.com/user-attachments/assets/17cdd850-bff1-40ed-b203-ebea7c525976" />

Multi source:
<img width="737" height="637" alt="image" src="https://github.com/user-attachments/assets/ea4c0db5-b0c7-4447-b38a-1dd3e478df07" />

I think this is sufficiently different from the widget in cosmic-settings. That widget doesn't show anything when not selected, this shows a radiobutton, or an empty checkbox, which signals the single vs multiple source:
<img width="1090" height="1105" alt="image" src="https://github.com/user-attachments/assets/544f539d-cdaf-4adb-a04b-efb3899f3e14" />

___

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

